### PR TITLE
Fix typo

### DIFF
--- a/export.py
+++ b/export.py
@@ -86,7 +86,7 @@ class ProjectGenerator():
             logbody += "<< Results with the extension '%s' >>" % search
             logbody += '\n\n%s\n\n' % '\n'.join(found[search])
         # Write results to the logfile
-        source_list_path = join(os.getcwd(), 'tools', 'join')
+        source_list_path = join(os.getcwd(), 'tools', 'records')
         if not os.path.exists(source_list_path):
             os.makedirs(source_list_path)
         target_path = join(source_list_path, 'scrape.log')


### PR DESCRIPTION
I cant use the build (-b) as it is. Expecting the tools to be in the PATH is unreasonable. I tried to inherit from private_settings.py in the tools directory but that seems forced. Having workspace tools in the repo + the parent tools repo is just crazy!!! Dont have a good solution other than this feature just seems forced at the moment.
