### PR TITLE
Initial version of Copy files to exported dir

### DIFF
--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -24,12 +24,12 @@ def run(args):
     update(None, False, False, workspace.settings)
 
     if args.project:
-        workspace.export_project(args.project, args.tool)
+        workspace.export_project(args.project, args.tool, args.copy)
 
         if args.build:
             workspace.build_project(args.project, args.tool)
     else:
-        workspace.export_projects(args.tool)
+        workspace.export_projects(args.tool, arg.copy)
 
         if args.build:
             workspace.build_projects(args.project, args.tool)
@@ -46,3 +46,5 @@ def setup(subparser):
     subparser.add_argument(
         "-defdir", "--defdirectory",
         help="Path to the definitions, otherwise default (~/.pg/definitions) is used")
+    subparser.add_argument(
+        "-c", "--copy", action="store_true", help="Copy all files to the exported directory")

--- a/project_generator/exporters/exporter.py
+++ b/project_generator/exporters/exporter.py
@@ -50,19 +50,21 @@ class Exporter:
         if not os.path.exists(project_dir):
             os.makedirs(project_dir)
 
-        # Get number of how far we are from root, to set paths in the project
-        # correctly
-        count = 1
-        pdir = project_dir
-        while os.path.split(pdir)[0]:
-            pdir = os.path.split(pdir)[0]
-            count += 1
-        rel_path_output = ''
+        rel_path_output= ''
+        if data['copy_sources'] == False:
+            # Get number of how far we are from root, to set paths in the project
+            # correctly
+            count = 1
+            pdir = project_dir
+            while os.path.split(pdir)[0]:
+                pdir = os.path.split(pdir)[0]
+                count += 1
+            rel_path_output = ''
 
-        dest['rel_count'] = count
-        while count:
-            rel_path_output = join('..', rel_path_output)
-            count = count - 1
+            dest['rel_count'] = count
+            while count:
+                rel_path_output = join('..', rel_path_output)
+                count = count - 1
         dest['dest_path'] = project_dir
         dest['rel_path'] = rel_path_output
         return dest

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -47,6 +47,16 @@ def flatten(*args):
         else:
             yield x
 
+FILES_EXTENSIONS = {
+    'include_paths' : ['h', 'hpp', 'inc'],
+    'source_files_s' : ['s'],
+    'source_files_c' : ['c'],
+    'source_files_cpp' : ['cpp', 'cc'],
+    'source_files_lib' : ['lib', 'ar', 'a'],
+    'source_files_obj' : ['o'],
+    'linker_file' : ['sct', 'ld', 'lin', 'icf'],
+}
+
 class ToolSpecificSettings:
 
     """represents the settings that are specifc to targets"""
@@ -422,26 +432,26 @@ class Project:
             if not os.path.exists(dest_dir) and len(files):
                 os.makedirs(dest_dir)
             for filename in files:
-                if filename.split('.')[-1] in ['h', 'hpp', 'inc']:
+                if filename.split('.')[-1] in FILES_EXTENSIONS['include_paths']:
                     shutil.copy2(os.path.join(os.getcwd(), path, filename), os.path.join(os.getcwd(), output_dir, path))
 
         for k,v in proj_dic['source_files_c'][0].items():
             for file in v:
-                self._copy_files(file, output_dir, ['c'])
+                self._copy_files(file, output_dir, FILES_EXTENSIONS['source_files_c'])
 
         for k,v in proj_dic['source_files_cpp'][0].items():
             for file in v:
-                self._copy_files(file, output_dir, ['cpp', 'cc'])
+                self._copy_files(file, output_dir, FILES_EXTENSIONS['source_files_cpp'])
 
         for k,v in proj_dic['source_files_s'][0].items():
             for file in v:
-                self._copy_files(file, output_dir, ['s'])
+                self._copy_files(file, output_dir, FILES_EXTENSIONS['source_files_s'])
 
         for file in proj_dic['source_files_obj']:
-            self._copy_files(file, output_dir, ['obj', 'o'])
+            self._copy_files(file, output_dir, FILES_EXTENSIONS['source_files_obj'])
 
         for file in proj_dic['source_files_lib']:
-            self._copy_files(file, output_dir, ['lib', 'ar', 'a'])
+            self._copy_files(file, output_dir, FILES_EXTENSIONS['source_files_lib'])
 
         linker = os.path.normpath(proj_dic['linker_file'])
         dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(linker))
@@ -460,9 +470,9 @@ class Project:
             }
         }
 
-        linker_filetypes = ['sct', 'ld', 'lin', 'icf']
-        source_filetypes = ['c', 'cpp', 'cc']
-        include_filetypes = ['h', 'hpp', 'inc']
+        linker_filetypes = FILES_EXTENSIONS['linker_file']
+        source_filetypes = FILES_EXTENSIONS['source_files_c'] + FILES_EXTENSIONS['source_files_cpp'] + FILES_EXTENSIONS['source_files_s']
+        include_filetypes = FILES_EXTENSIONS['include_paths']
 
         for dirpath, dirnames, files in os.walk(directory):
             for filename in files:

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -395,6 +395,14 @@ class Project:
         exporter =  self.tools.get_value(tool, 'exporter')
         fixup_executable(exporter, executable_path, tool)
 
+    def _copy_files(self, file, output_dir, valid_files_group):
+        file = os.path.normpath(file)
+        dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
+        if not os.path.exists(dest_dir):
+            os.makedirs(dest_dir)
+        if file.split('.')[-1] in valid_files_group:
+            shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
+
     def copy_files(self, proj_dic, tool):
         if self.workspace.settings.generated_projects_dir != self.workspace.settings.generated_projects_dir_default:
             # TODO: same as in exporters.py - create keyword parser and in clean method above
@@ -407,8 +415,6 @@ class Project:
              output_dir = os.path.join(self.project_dir['path'], "%s_%s" % (tool, self.name))
         output_dir = os.path.normpath(output_dir)
 
-        # create list of all files to copy
-
         for path in proj_dic['include_paths']:
             path = os.path.normpath(path)
             files = os.listdir(path)
@@ -420,47 +426,22 @@ class Project:
                     shutil.copy2(os.path.join(os.getcwd(), path, filename), os.path.join(os.getcwd(), output_dir, path))
 
         for k,v in proj_dic['source_files_c'][0].items():
-                for file in v:
-                    file = os.path.normpath(file)
-                    dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
-                    if not os.path.exists(dest_dir):
-                        os.makedirs(dest_dir)
-                    if file.split('.')[-1] == 'c':
-                        shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
+            for file in v:
+                self._copy_files(file, output_dir, ['c'])
 
         for k,v in proj_dic['source_files_cpp'][0].items():
-                for file in v:
-                    file = os.path.normpath(file)
-                    dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
-                    if not os.path.exists(dest_dir):
-                        os.makedirs(dest_dir)
-                    if file.split('.')[-1] in ['cpp', 'cc']:
-                        shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
+            for file in v:
+                self._copy_files(file, output_dir, ['cpp', 'cc'])
 
         for k,v in proj_dic['source_files_s'][0].items():
-                for file in v:
-                    file = os.path.normpath(file)
-                    dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
-                    if not os.path.exists(dest_dir):
-                        os.makedirs(dest_dir)
-                    if file.split('.')[-1] in ['s']:
-                        shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
+            for file in v:
+                self._copy_files(file, output_dir, ['s'])
 
         for file in proj_dic['source_files_obj']:
-                file = os.path.normpath(file)
-                dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
-                if not os.path.exists(dest_dir):
-                    os.makedirs(dest_dir)
-                if file.split('.')[-1] in ['obj', 'o']:
-                    shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
+            self._copy_files(file, output_dir, ['obj', 'o'])
 
         for file in proj_dic['source_files_lib']:
-                file = os.path.normpath(file)
-                dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
-                if not os.path.exists(dest_dir):
-                    os.makedirs(dest_dir)
-                if file.split('.')[-1] in ['lib', 'ar', 'a']:
-                    shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
+            self._copy_files(file, output_dir, ['lib', 'ar', 'a'])
 
         linker = os.path.normpath(proj_dic['linker_file'])
         dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(linker))

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -416,7 +416,7 @@ class Project:
             if not os.path.exists(dest_dir) and len(files):
                 os.makedirs(dest_dir)
             for filename in files:
-                if os.path.splitext(filename)[1] == '.h':
+                if filename.split('.')[-1] in ['h', 'hpp', 'inc']:
                     shutil.copy2(os.path.join(os.getcwd(), path, filename), os.path.join(os.getcwd(), output_dir, path))
 
         for k,v in proj_dic['source_files_c'][0].items():
@@ -425,7 +425,7 @@ class Project:
                     dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
                     if not os.path.exists(dest_dir):
                         os.makedirs(dest_dir)
-                    if os.path.splitext(file)[1] == '.c':
+                    if file.split('.')[-1] == 'c':
                         shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
 
         for k,v in proj_dic['source_files_cpp'][0].items():
@@ -434,7 +434,7 @@ class Project:
                     dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
                     if not os.path.exists(dest_dir):
                         os.makedirs(dest_dir)
-                    if os.path.splitext(file)[1] == '.cpp':
+                    if file.split('.')[-1] in ['cpp', 'cc']:
                         shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
 
         for k,v in proj_dic['source_files_s'][0].items():
@@ -443,8 +443,24 @@ class Project:
                     dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
                     if not os.path.exists(dest_dir):
                         os.makedirs(dest_dir)
-                    if os.path.splitext(file)[1] == '.s':
+                    if file.split('.')[-1] in ['s']:
                         shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
+
+        for file in proj_dic['source_files_obj']:
+                file = os.path.normpath(file)
+                dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
+                if not os.path.exists(dest_dir):
+                    os.makedirs(dest_dir)
+                if file.split('.')[-1] in ['obj', 'o']:
+                    shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
+
+        for file in proj_dic['source_files_lib']:
+                file = os.path.normpath(file)
+                dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(file))
+                if not os.path.exists(dest_dir):
+                    os.makedirs(dest_dir)
+                if file.split('.')[-1] in ['lib', 'ar', 'a']:
+                    shutil.copy2(os.path.join(os.getcwd(), file), os.path.join(os.getcwd(), output_dir, file))
 
         linker = os.path.normpath(proj_dic['linker_file'])
         dest_dir = os.path.join(os.getcwd(), output_dir, os.path.dirname(linker))

--- a/project_generator/workspace.py
+++ b/project_generator/workspace.py
@@ -40,7 +40,7 @@ class Workspace:
         else:
             logging.debug("No projects found in the main record file.")
 
-    def export_project(self, project_name, tool):
+    def export_project(self, project_name, tool, copy):
         if project_name not in self.projects:
             raise RuntimeError("Invalid Project Name")
 
@@ -49,16 +49,16 @@ class Workspace:
         if tool is None:
             tool = self.settings.DEFAULT_TOOL
 
-        self.projects[project_name].export(tool)
+        self.projects[project_name].export(tool, copy)
 
-    def export_projects(self, tool):
+    def export_projects(self, tool, copy):
         if tool is None:
             tool = self.settings.DEFAULT_TOOL
         
         for name, project in self.projects.items():
             logging.debug("Exporting Project %s" % name)
 
-            project.export(tool)
+            project.export(tool, copy)
 
     def build_projects(self, tool):
         if tool is None:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [str(requirement.req) for requirement in parse_requirements('requ
 
 setup(
     name='project_generator',
-    version='0.5.9',
+    version='0.6.0-alpha',
     description='Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!',
     author='Martin Kojtal, Matthew Else',
     author_email='c0170@rocketmail.com, matthewelse1997@gmail.com',


### PR DESCRIPTION
This is work in progress, needs cleaning. Although I tested and this is working.

Added new option to pgen export -c as --copy, means copy all files used for the compilation (includes, source files, linker, will add also objects and libraries). For example

```
export -f projects.yaml -p lpc1768_blinky -t uvision -c
```

This command will mirror all required files to the exported dir. Useful for IDE, or for us when you want to obtain a working project within a repository. :smile: 

Please test , review ! First PR for v0.6 :-)