### PR TITLE
Update - rework to use either local dir or default github repository

### DIFF
--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -21,7 +21,10 @@ help = 'Export a project record'
 def run(args):
     workspace = Workspace(args.file, os.getcwd())
 
-    update(None, False, False, workspace.settings)
+    if args.defdirectory:
+        workspace.settings.update_definitions_dir(args.defdirectory)
+    else:
+        update(False, workspace.settings)
 
     if args.project:
         workspace.export_project(args.project, args.tool, args.copy)

--- a/project_generator/exporters/coide.py
+++ b/project_generator/exporters/coide.py
@@ -119,6 +119,8 @@ class CoideExporter(Exporter):
         self.parse_specific_options(expanded_dic)
 
         target = Targets(env_settings.get_env_settings('definitions'))
+        if not target.is_supported(expanded_dic['target'].lower(), 'coide'):
+            raise RuntimeError("Target %s is not supported." % expanded_dic['target'].lower())
         mcu_def_dic = target.get_tool_def(expanded_dic['target'].lower(), 'coide')
         if not mcu_def_dic:
              raise RuntimeError(

--- a/project_generator/exporters/iar.py
+++ b/project_generator/exporters/iar.py
@@ -130,6 +130,8 @@ class IAREWARMExporter(Exporter):
         self.parse_specific_options(expanded_dic)
 
         target = Targets(env_settings.get_env_settings('definitions'))
+        if not target.is_supported(expanded_dic['target'].lower(), 'iar'):
+            raise RuntimeError("Target %s is not supported." % expanded_dic['target'].lower())
         mcu_def_dic = target.get_tool_def(expanded_dic['target'].lower(), 'iar')
         if not mcu_def_dic:
              raise RuntimeError(

--- a/project_generator/exporters/uvision.py
+++ b/project_generator/exporters/uvision.py
@@ -167,7 +167,8 @@ class UvisionExporter(Exporter):
         self.parse_specific_options(expanded_dic)
 
         target = Targets(env_settings.get_env_settings('definitions'))
-
+        if not target.is_supported(expanded_dic['target'].lower(), 'uvision'):
+            raise RuntimeError("Target %s is not supported." % expanded_dic['target'].lower())
         mcu_def_dic = target.get_tool_def(expanded_dic['target'].lower(), 'uvision')
         if not mcu_def_dic:
              raise RuntimeError(

--- a/project_generator/settings.py
+++ b/project_generator/settings.py
@@ -42,7 +42,8 @@ class ProjectSettings:
             'IAR Systems', 'Embedded Workbench 7.0',
             'common', 'bin', 'IarBuild.exe')
         self.paths['gcc'] = os.environ.get('ARM_GCC_PATH') or ''
-        self.paths['definitions'] = join(expanduser('~/.pg'), 'definitions')
+        self.paths['definitions_default'] = join(expanduser('~/.pg'), 'definitions')
+        self.paths['definitions'] = self.paths['definitions_default']
         if not os.path.exists(join(expanduser('~/.pg'))):
             os.mkdir(join(expanduser('~/.pg')))
         self.generated_projects_dir_default = 'generated_projects'
@@ -59,8 +60,8 @@ class ProjectSettings:
         if 'export_dir' in settings:
             self.generated_projects_dir = normpath(settings['export_dir'][0])
 
-    def set_definitions_file(self, def_dir):
-        self.paths['definitions'] = def_dir
+    def update_definitions_dir(self, def_dir):
+        self.generated_projects_dir = normpath(def_dir)
 
     def get_env_settings(self, env_set):
         return self.paths[env_set]


### PR DESCRIPTION
Definitions - either use local source or the default github repository.
To overwrite the default, use settings keyword in the project record. The code below shows, take this definitions which are my local/or my new fork for testing the new target:

```
settings:
    definitions_dir:
        - project_generator_definitions
``` 

We can introduce the configuration file later on, and have it overwrite only once + paths. That's a discussion for another time.