### PR TITLE
Start to move documentation from wiki

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# Welcome to Project Generator
+
+Source code is often times simple but building it is difficult when more than one person is involved. Developers like what they like: IDE, compiler, debugger and really all we want is to produce an executable. Sharing project files decoding XML in commit messages because someone was debugging and changed compile options before commiting distracts from doing what you want to do; develop software.
+
+This project allows you to define a project in text using YAML files and generate IDE project files based on the rules defined in records. No one should ever commit IDE specific project file to a repository again!
+
+All open sourced - licensed under Apache v2.0 license.
+
+## Installation
+
+Project Generator can be installed using pip:
+
+```shell
+pip install project_generator
+```
+
+You can then check that project generator is accessible from your command line, using either `pgen` or `project_generator`.
+
+```shell
+pgen --version
+```
+
+If you want, you can also run project generator directly from the respository, by saving this as `run.py`:
+
+```python
+from project_generator.main import main
+
+main()
+```
+
+You can then use run.py just like you would use the command:
+
+```shell
+python run.py --version
+```
+
+To start using project_generator with a project, see the [getting started guide](getting_started.md).
+

--- a/docs/reference/projects.md
+++ b/docs/reference/projects.md
@@ -1,0 +1,23 @@
+# projects.yaml Reference
+
+## Projects
+
+## Settings
+
+### Toolchain Paths
+
+projects.yaml can be used to specify workspace-wide paths for toolchains. These can be specified as follows:
+
+```yaml
+settings:
+    tool:
+        iar:
+            path: path/to/iar
+        uvision:
+            path: path/to/uvision
+        gcc:
+            path: path/to/gcc
+```
+
+If these toolchains are already in your PATH, Project Generator will try to access uVision by calling `UV4`, IAR by calling `IARBUILD` and ARM GCC by looking in `ARM_GCC_PATH`
+

--- a/docs/user-guide/getting_started.md
+++ b/docs/user-guide/getting_started.md
@@ -1,0 +1,62 @@
+# Project Structure
+
+Here's an example directory tree for a typical Project Generator project, which you can see [on Github](https://github.com/project-generator/project_generator_mbed_examples). 
+
+**Throughout all of the yaml files in your project, always use relative paths specified from the root of your project.**
+
+```
+├── LICENSE
+├── README.md
+├── examples
+│   └── blinky
+│       └── main.cpp
+├── mbed
+├── projects.yaml
+└── records
+    ├── mbed
+    │   ├── common.yaml
+    │   ├── disco_f407vg_cmsis.yaml
+    │   ├── disco_f407vg_target.yaml
+    │   ├── frdm_k64f_target.yaml
+    │   ├── freescale_ksdk.yaml
+    │   ├── k20_cmsis.yaml
+    │   ├── k20_target.yaml
+    │   ├── k64f_cmsis.yaml
+    │   ├── k64f_target.yaml
+    │   ├── lpc1768_cmsis.yaml
+    │   ├── lpc1768_target.yaml
+    │   └── proj_set.yaml
+    └── projects
+        ├── disco_f407vg_blinky.yaml
+        ├── frdm_k64f_blinky.yaml
+        ├── k20_blinky.yaml
+        └── lpc1768_blinky.yaml
+```
+
+## Projects File
+
+The Projects YAML file (by default projects.yaml) defines one or more projects for a repository, as well as environment settings for toolchains. Each project consists of a list of files which each define a module, which together build the project. By default, Project Generator includes sane defaults, which can be changed to fit your project.
+
+The following example specifies one project, called `my_project`, which contains one module, called `main`, as well as specifying settings which allow Project Generator to use the iar toolchain.
+
+```yaml
+projects:
+    my_project:
+        - main.yaml
+
+settings:
+    tool:
+        iar:
+            path:
+                - path/to/iar
+```
+
+For more details about settings you can specify in projects.yaml, see the projects.yaml documentation **(TODO)**.
+
+## Project Records
+
+Project record files can be stored anywhere within project directory, however the most common place to put them is within a subdirectory called `records`. These specify attributes for a project or module, such as files and compiler options.
+
+Since each project can have more than one record, you can create yaml files for different targets, which can be reused between projects.
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: Project Generator
+
+theme: readthedocs
+
+pages:
+    - Home: 'index.md'
+    - User Guide:
+        - 'Getting Started': 'user-guide/getting_started.md'
+    - Reference:
+        - 'projects.yaml': 'reference/projects.md'
+
+repo_url: https://github.com/project-generator/project_generator/
+copyright: Copyright 2015 0xc0170


### PR DESCRIPTION
I've started to move some of the documentation from the wiki to a readthedocs/gh-pages friendly format, as well as proposing a new layout of the docs, where we can specify detailed documentation for all of the different settings you can use, as well as an introduction.

It uses mkdocs, and then to view the docs as they would appear, you can do `mkdocs serve` from the root if you want to have a look at it... I haven't moved everything from the wiki yet, since there's a lot to do and it would be nice to discuss organising all of the documentation too.

See #164 for the original issue. I've included an image of what this looks like running on my computer for reference.

![image](https://cloud.githubusercontent.com/assets/759697/8331704/9df6f8ea-1a81-11e5-8415-f4e1e2b13234.png)
