### PR TITLE
Fix export dir

### DIFF
--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -471,19 +471,23 @@ class Project:
 
     def _set_output_dir_path(self, tool, workspace_path):
         if self.pgen_workspace.settings.generated_projects_dir != self.pgen_workspace.settings.generated_projects_dir_default:
+            # global settings defined, replace keys pgen is familiar, this overrides anything in the project
             output_dir = Template(self.pgen_workspace.settings.generated_projects_dir)
             output_dir = output_dir.substitute(target=self.project['target'], workspace=self._get_workspace_name(),
                                                project_name=self.name, tool=tool)
         else:
             if self.project['export_dir'] == self.pgen_workspace.settings.generated_projects_dir_default:
+                # if export_dir is not defined we use tool_name for a project
                 project_name = "%s_%s" % (tool, self.name)
             else:
                 project_name = ""
+            # TODO: below works only if we are using default export dir, will blow up with user defined paths
             if workspace_path:
                 output_dir = os.path.join(self.project['export_dir'], workspace_path, project_name)
             else:
                 output_dir = os.path.join(self.project['export_dir'], project_name)
             self.pgen_workspace.settings.generated_projects_dir_default
+        # After all adjusting , set the output_dir path, which tools will use to export a project
         self.project['output_dir']['path'] = os.path.normpath(output_dir)
 
     @staticmethod

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -65,8 +65,8 @@ class ToolSpecificSettings:
         if 'macros' in data_dictionary:
             self.macros.extend([x for x in data_dictionary['macros'] if x is not None])
 
-        if 'project_dir' in data_dictionary:
-            self.project_dir.update(data_dictionary['project_dir'])
+        if 'export_dir' in data_dictionary:
+            self.export_dir.update(data_dictionary['export_dir'])
 
         if 'linker_file' in data_dictionary:
             self.linker_file = data_dictionary['linker_file'][0]
@@ -229,11 +229,8 @@ class Project:
             'source_files_lib': [{}],   # [internal] libraries
             'macros': [],               # macros (defines)
             'misc': {},                 # misc tools settings, which are parsed by tool
-            'project_dir': {            # Name and path for a project
-                'name': '.' + os.path.sep,
-                'path' : self.pgen_workspace.settings.generated_projects_dir_default
-            },
-            'output_dir': {         # The generated path dict
+            'export_dir': self.pgen_workspace.settings.generated_projects_dir_default, # Export path for a project
+            'output_dir': {             # The generated path dict
                 'path': '',
                 'rel_path': '',
                 'rel_count': '',
@@ -272,9 +269,8 @@ class Project:
                     self.project['macros'].extend(
                         [x for x in project_file_data['common']['macros'] if x is not None])
 
-                if 'project_dir' in project_file_data['common']:
-                    self.project['project_dir'].update(
-                        project_file_data['common']['project_dir'])
+                if 'export_dir' in project_file_data['common']:
+                    self.project['export_dir'] = project_file_data['common']['export_dir'][0]
 
                 for key in ['debugger','build_dir','mcu','name','target','core', 'linker_file']:
                     if key in project_file_data['common']:
@@ -354,7 +350,7 @@ class Project:
                 path = path.substitute(target=self.project['target'], workspace=self._get_workspace_name(),
                                         project_name=self.name, tool=tool)
             else:
-                 path = os.path.join(self.project_dir['path'], "%s_%s" % (current_tool, self.name))
+                 path = os.path.join(self.project['export_dir'], "%s_%s" % (current_tool, self.name))
             if os.path.isdir(path):
                 logging.info("Cleaning directory %s" % path)
 
@@ -409,8 +405,8 @@ class Project:
             self.project['output_dir']['rel_path'] = rel_path_output
 
     def _get_project_files(self):
-        if self.project['project_dir']['name'] and self.project['project_dir']['path']:
-            return [os.path.join(self.project['project_dir']['path'], self.project['project_dir']['name'])]
+        if self.project['export_dir']:
+            return [os.path.join(self.project['export_dir']['path'], self.name)]
         else:
             return [os.path.join(self.project['output_dir']['path'], self.project['name'])]
 
@@ -480,9 +476,9 @@ class Project:
                                                project_name=self.name, tool=tool)
         else:
             if workspace_path:
-                output_dir = os.path.join(self.project['project_dir']['path'], workspace_path, "%s_%s" % (tool, self.name))
+                output_dir = os.path.join(self.project['export_dir'], workspace_path, "%s_%s" % (tool, self.name))
             else:
-                output_dir = os.path.join(self.project['project_dir']['path'], "%s_%s" % (tool, self.name))
+                output_dir = os.path.join(self.project['export_dir'], "%s_%s" % (tool, self.name))
         self.project['output_dir']['path'] = os.path.normpath(output_dir)
 
     @staticmethod

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -270,7 +270,7 @@ class Project:
                         [x for x in project_file_data['common']['macros'] if x is not None])
 
                 if 'export_dir' in project_file_data['common']:
-                    self.project['export_dir'] = project_file_data['common']['export_dir'][0]
+                    self.project['export_dir'] = os.path.normpath(project_file_data['common']['export_dir'][0])
 
                 for key in ['debugger','build_dir','mcu','name','target','core', 'linker_file']:
                     if key in project_file_data['common']:
@@ -406,7 +406,7 @@ class Project:
 
     def _get_project_files(self):
         if self.project['export_dir']:
-            return [os.path.join(self.project['export_dir']['path'], self.name)]
+            return [os.path.join(self.project['export_dir']['path'], self.project['name'])]
         else:
             return [os.path.join(self.project['output_dir']['path'], self.project['name'])]
 
@@ -475,10 +475,15 @@ class Project:
             output_dir = output_dir.substitute(target=self.project['target'], workspace=self._get_workspace_name(),
                                                project_name=self.name, tool=tool)
         else:
-            if workspace_path:
-                output_dir = os.path.join(self.project['export_dir'], workspace_path, "%s_%s" % (tool, self.name))
+            if self.project['export_dir'] == self.pgen_workspace.settings.generated_projects_dir_default:
+                project_name = "%s_%s" % (tool, self.name)
             else:
-                output_dir = os.path.join(self.project['export_dir'], "%s_%s" % (tool, self.name))
+                project_name = ""
+            if workspace_path:
+                output_dir = os.path.join(self.project['export_dir'], workspace_path, project_name)
+            else:
+                output_dir = os.path.join(self.project['export_dir'], project_name)
+            self.pgen_workspace.settings.generated_projects_dir_default
         self.project['output_dir']['path'] = os.path.normpath(output_dir)
 
     @staticmethod

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -230,10 +230,10 @@ class Project:
             'macros': [],               # macros (defines)
             'misc': {},                 # misc tools settings, which are parsed by tool
             'export_dir': self.pgen_workspace.settings.generated_projects_dir_default, # Export path for a project
-            'output_dir': {             # The generated path dict
-                'path': '',
-                'rel_path': '',
-                'rel_count': '',
+            'output_dir': {             # [internal] The generated path dict
+                'path': '',             # path with all name mangling we add to export_dir
+                'rel_path': '',         # how far we are from root
+                'rel_count': '',        # Contains count of how far we are from root, used for eclipse for example
             },
             'target': '',       # target
             'template' : '',    # tool template

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -138,13 +138,18 @@ class IAREmbeddedWorkbenchProject:
     def _eww_set_path_single_project(self, eww_dic, name):
         eww_dic['workspace']['project']['path'] = join('$WS_DIR$', name + '.ewp')
 
-    def _eww_set_path_multiple_project(self, eww_dic, projects):
+    def _eww_set_path_multiple_project(self, eww_dic):
         eww_dic['workspace']['project'] = []
         for project in self.workspace['projects']:
-            # This has an assumption all projects inside workspace
-            path_to_project = project['output_dir']['path']
-            path_to_project = path_to_project.replace(self.workspace['settings']['path'] + '\\', '', 1)
-            eww_dic['workspace']['project'].append( { 'path' : join('$WS_DIR$', path_to_project, project['name'] + '.ewp') })
+            # We check how far is project from root and workspace. IF they dont match,
+            # get relpath for project and inject it into workspace
+            path_project = os.path.dirname(project['output_dir']['path'] + '\\')
+            path_workspace = os.path.dirname(self.workspace['settings']['path'] + '\\')
+            # path_to_project = path_to_project.replace( + '\\', '', 1)
+            if path_project != path_workspace:
+                rel_path = os.path.relpath(os.getcwd(), path_workspace)
+                path_project = os.path.join(rel_path, path_project)
+            eww_dic['workspace']['project'].append( { 'path' : join('$WS_DIR$', path_project, project['name'] + '.ewp') })
 
     def _ewp_set_target(self, ewp_dic, mcu_def_dic):
         index_general = self._get_option(ewp_dic['project']['configuration']['settings'], 'General')

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -209,10 +209,15 @@ class Uvision(Builder, Exporter):
         uvmpw_dic['ProjectWorkspace']['project'] = []
 
         for project in self.workspace['projects']:
-            # This has an assumption all projects inside workspace
-            path_to_project = project['output_dir']['path']
-            path_to_project = path_to_project.replace(self.workspace['settings']['path'] + '\\', '', 1)
-            uvmpw_dic['ProjectWorkspace']['project'].append({'PathAndName': os.path.join(path_to_project, project['name'] + '.uvproj')})
+            # We check how far is project from root and workspace. IF they dont match,
+            # get relpath for project and inject it into workspace
+            path_project = os.path.dirname(project['output_dir']['path'] + '\\')
+            path_workspace = os.path.dirname(self.workspace['settings']['path'] + '\\')
+            # path_to_project = path_to_project.replace( + '\\', '', 1)
+            if path_project != path_workspace:
+                rel_path = os.path.relpath(os.getcwd(), path_workspace)
+                path_project = os.path.join(rel_path, path_project)
+            uvmpw_dic['ProjectWorkspace']['project'].append({'PathAndName': os.path.join(path_project, project['name'] + '.uvproj')})
 
         # generate the file
         uvmpw_xml = xmltodict.unparse(uvmpw_dic, pretty=True)

--- a/tests/test_tools/test_uvision.py
+++ b/tests/test_tools/test_uvision.py
@@ -57,3 +57,13 @@ class TestProject(TestCase):
 
     def test_export_project(self):
         self.workspace.export_project('project_1', 'uvision', False)
+
+    def test_export_project_to_diff_directory(self):
+        project_1_yaml['common']['export_dir'] = ['create_this_folder']
+        with open(os.path.join(os.getcwd(), 'test_workspace/project_1.yaml'), 'wt') as f:
+            f.write(yaml.dump(project_1_yaml, default_flow_style=False))
+        workspace = PgenWorkspace('test_workspace/projects.yaml')
+        workspace.export_project('project_1', 'uvision', False)
+
+        assert os.path.isdir('create_this_folder')
+        shutil.rmtree('create_this_folder')


### PR DESCRIPTION
project_dir does not make much sense, for a project, should be export_dir as it is a dir where a project will be exported.

I added comments for project dic for output_dir and export_dir for better understanding how are those paths used.