### PR TITLE
Add format string support for export locations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ install:
     - pip install .
     - pip install -r tests/requirements.txt
     # - ./tests/setup.sh
-script: nosetests --with-coverage --cover-package=project_generator
+script: nosetests -v --with-coverage --cover-package=project_generator
 after_success: coveralls
 sudo: false

--- a/project_generator/commands/build.py
+++ b/project_generator/commands/build.py
@@ -24,21 +24,14 @@ help = 'Build a project'
 
 def run(args):
     # Export if we know how, otherwise return
-    if args.file:
-        args.copy = False
-        args.build = False
-        export.run(args)
-    else:
-        if not os.path.exists(os.path.join(args.directory, args.project)):
-            logging.debug("The project: %s does not exist." % os.path.join(args.directory, args.project))
-            return
-
-    if args.file:
+    if os.path.exists(args.file):
         # known project from records
         workspace = PgenWorkspace(args.file, os.getcwd())
         if args.project:
+            workspace.export_project(args.project, args.tool, False)
             workspace.build_project(args.project, args.tool)
         else:
+            workspace.export_projects(args.tool, False)
             workspace.build_projects(args.tool)
     else:
         # not project known by pgen

--- a/project_generator/main.py
+++ b/project_generator/main.py
@@ -15,7 +15,13 @@
 import argparse
 import os
 import logging
-import chromalog
+
+colourful = True
+
+try:
+    import chromalog
+except ImportError:
+    colourful = False
 
 import pkg_resources
 
@@ -59,7 +65,11 @@ def main():
     verbosity = args.verbosity - args.quietness
 
     logging_level = max(logging.INFO - (10 * verbosity), 0)
-    chromalog.basicConfig(format="%(levelname)s\t%(message)s", level=logging_level)
+
+    if colourful:
+        chromalog.basicConfig(format="%(levelname)s\t%(message)s", level=logging_level)
+    else:
+        logging.basicConfig(format="%(levelname)s\t%(message)s", level=logging_level)
 
     logging.debug('This should be the project root: %s', os.getcwd())
 

--- a/project_generator/main.py
+++ b/project_generator/main.py
@@ -15,6 +15,7 @@
 import argparse
 import os
 import logging
+import chromalog
 
 import pkg_resources
 
@@ -58,7 +59,7 @@ def main():
     verbosity = args.verbosity - args.quietness
 
     logging_level = max(logging.INFO - (10 * verbosity), 0)
-    logging.basicConfig(level=logging_level)
+    chromalog.basicConfig(format="%(levelname)s\t%(message)s", level=logging_level)
 
     logging.debug('This should be the project root: %s', os.getcwd())
 

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -415,12 +415,17 @@ class Project:
         self.project['copy_sources'] = True
         self.copy_files()
 
+    @staticmethod
+    def _generate_output_dir(path):
+        """this is a separate function, so that it can be more easily tested."""
+
+        count = path.count(os.sep) + 1
+
+        return (os.sep.join('..' for _ in range(count)) + os.sep), count
+
     def _set_output_dir(self):
         path = self.project['output_dir']['path']
-        count = path.count('/') + 1
-
-        self.project['output_dir']['rel_path'] = ('/'.join('..' for _ in range(count)) + '/')
-        self.project['output_dir']['rel_count'] = count
+        self.project['output_dir']['rel_path'], self.project['output_dir']['rel_count'] = self._generate_output_dir(path)
 
     def source_of_type(self, filetype):
         """return a dictionary of groups and the sources of a specified type within them"""

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -341,19 +341,16 @@ class Project:
                     return workspace
 
     def clean(self, project_name, tool):
-        if tool is None:
-            tools = list(self.TOOLCHAINS)
+        tools = []
+        if not tool:
+            tools = self.project['tools_supported']
         else:
             tools = [tool]
 
         for current_tool in tools:
-            if self.pgen_workspace.settings.generated_projects_dir != self.pgen_workspace.settings.generated_projects_dir_default:
-                # TODO: same as in exporters.py - create keyword parser
-                path = Template(self.pgen_workspace.settings.generated_projects_dir)
-                path = path.substitute(target=self.project['target'], workspace=self._get_workspace_name(),
-                                        project_name=self.name, tool=tool)
-            else:
-                 path = os.path.join(self.project['export_dir'], "%s_%s" % (current_tool, self.name))
+            self._set_output_dir_path(current_tool)
+            path = self.project['output_dir']['path']
+
             if os.path.isdir(path):
                 logging.info("Cleaning directory %s" % path)
 
@@ -392,6 +389,8 @@ class Project:
 
         for build_tool in tools:
             builder = self.tools.get_value(build_tool, 'builder')
+            logging.debug("Building for tool: %s", build_tool)
+            logging.debug(self.generated_files)
             builder(self.generated_files[build_tool], self.pgen_workspace.settings).build_project()
 
     def flash(self, tool):

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -20,7 +20,7 @@ import operator
 
 from collections import defaultdict
 from .tool import ToolsSupported
-from .util import merge_recursive, flatten
+from .util import merge_recursive, flatten, PartialFormatter
 from string import Template
 
 FILES_EXTENSIONS = {
@@ -495,8 +495,8 @@ class Project:
                 location_format = self.pgen_workspace.settings.export_location_format
 
         # substitute all of the different dynamic values
-        location = location_format.format(**{
-            'name': self.name,
+        location = PartialFormatter().format(location_format, **{
+            'project_name': self.name,
             'tool': tool,
             'target': self.project['target'],
             'workspace': self._get_workspace_name() or '.'

--- a/project_generator/settings.py
+++ b/project_generator/settings.py
@@ -29,6 +29,8 @@ class ProjectSettings:
     PROJECT_ROOT = os.environ.get('PROJECT_GENERATOR_ROOT') or join(pardir, pardir)
     DEFAULT_TOOL = os.environ.get('PROJECT_GENERATOR_DEFAULT_TOOL') or 'uvision'
 
+    DEFAULT_EXPORT_LOCATION_FORMAT = join('generated_projects', '{tool}_{name}')
+
     def __init__(self):
         """ This are default enviroment settings for build tools. To override,
         define them in the projects.yaml file. """
@@ -45,8 +47,8 @@ class ProjectSettings:
         self.paths['definitions'] = self.paths['definitions_default']
         if not os.path.exists(join(expanduser('~/.pg'))):
             os.mkdir(join(expanduser('~/.pg')))
-        self.generated_projects_dir_default = 'generated_projects'
-        self.generated_projects_dir = self.generated_projects_dir_default
+
+        self.export_location_format = self.DEFAULT_EXPORT_LOCATION_FORMAT
 
     def update(self, settings):
         if settings:
@@ -62,7 +64,7 @@ class ProjectSettings:
                 self.paths['definitions'] = normpath(settings['definitions_dir'][0])
 
             if 'export_dir' in settings:
-                self.generated_projects_dir = normpath(settings['export_dir'][0])
+                self.export_location_format = normpath(settings['export_dir'][0])
 
     def update_definitions_dir(self, def_dir):
         self.paths['definitions'] = normpath(def_dir)

--- a/project_generator/settings.py
+++ b/project_generator/settings.py
@@ -29,7 +29,7 @@ class ProjectSettings:
     PROJECT_ROOT = os.environ.get('PROJECT_GENERATOR_ROOT') or join(pardir, pardir)
     DEFAULT_TOOL = os.environ.get('PROJECT_GENERATOR_DEFAULT_TOOL') or 'uvision'
 
-    DEFAULT_EXPORT_LOCATION_FORMAT = join('generated_projects', '{tool}_{name}')
+    DEFAULT_EXPORT_LOCATION_FORMAT = join('generated_projects', '{tool}_{project_name}')
 
     def __init__(self):
         """ This are default enviroment settings for build tools. To override,

--- a/project_generator/util.py
+++ b/project_generator/util.py
@@ -12,10 +12,12 @@
 # limitations under the License.
 
 import os
-import shutil
-import locale
-import operator
 import yaml
+import locale
+import shutil
+import string
+import operator
+
 from functools import reduce
 
 def rmtree_if_exists(directory):
@@ -58,3 +60,12 @@ def load_yaml_records(yaml_files):
         except IOError:
            raise IOError("The file %s referenced in main yaml doesn't exist." % project_file)
     return dictionaries
+
+class PartialFormatter(string.Formatter):
+    def get_field(self, field_name, args, kwargs):
+        try:
+            val = super(PartialFormatter, self).get_field(field_name, args, kwargs)
+        except (IndexError, KeyError, AttributeError):
+            first, _ = field_name._formatter_field_name_split()
+            val = '{' + field_name + '}', first
+        return val

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyYAML
 Jinja2
 argparse
 xmltodict
+chromalog

--- a/tests/test_pgenworkspace.py
+++ b/tests/test_pgenworkspace.py
@@ -58,7 +58,7 @@ class TestPgenWorkspace(TestCase):
     def test_settings(self):
         # only check things which are affected by projects.yaml
         assert self.workspace.settings.paths['definitions'] == os.path.normpath('notpg/path/somewhere')
-        assert self.workspace.settings.generated_projects_dir == 'not_generated_projects'
+        assert self.workspace.settings.export_location_format == 'not_generated_projects'
 
     def test_project(self):
         # project should not be empty and project_1 should exist, not empty neither

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -40,9 +40,15 @@ projects_yaml = {
     },
     'settings' : {
         'definitions_dir': ['notpg/path/somewhere'],
-        # 'export_dir': ['not_generated_projects']
+        'export_dir': ['projects/{workspace}/{tool}_{target}/{name}']
     }
 }
+
+def test_output_directory_formatting():
+    path, depth = Project._generate_output_dir('aaa/bbb/cccc/ddd/eee/ffff/ggg')
+
+    assert depth == 7
+    assert path == '../../../../../../../'
 
 class TestProject(TestCase):
 
@@ -80,7 +86,7 @@ class TestProject(TestCase):
         # test using yaml files and compare basic data
         project = Project('project_1',['test_workspace/project_1.yaml'],
             PgenWorkspace('test_workspace/projects.yaml'))
-        self.assertEqual(self.project.name, project.name)
+        assert self.project.name == project.name
         # fix this one, they should be equal
         #self.assertDictEqual(self.project.project, project.project)
 
@@ -94,3 +100,7 @@ class TestProject(TestCase):
 
         self.project._set_output_dir()
         self.project.copy_sources_to_generated_destination()
+
+    def test_set_output_dir_path(self):
+        self.project._set_output_dir_path('uvision')
+        assert self.project.project['output_dir']['path'] == 'projects/uvision_target1/project_1'

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -40,7 +40,7 @@ projects_yaml = {
     },
     'settings' : {
         'definitions_dir': ['notpg/path/somewhere'],
-        'export_dir': ['projects/{workspace}/{tool}_{target}/{name}']
+        'export_dir': ['projects/{workspace}/{tool}_{target}/{project_name}']
     }
 }
 
@@ -80,7 +80,7 @@ class TestProject(TestCase):
     def tearDown(self):
         # remove created directory
         shutil.rmtree('test_workspace', ignore_errors=True)
-        shutil.rmtree('generated_projects', ignore_errors=True)
+        shutil.rmtree('projects', ignore_errors=True)
 
     def test_project_yaml(self):
         # test using yaml files and compare basic data

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -45,7 +45,7 @@ class TestProject(TestCase):
         assert self.settings.get_env_settings('definitions') == settings_dict['definitions_dir'][0]
         assert self.settings.get_env_settings('iar') == settings_dict['tools']['iar']['path'][0]
         assert self.settings.get_env_settings('uvision') == settings_dict['tools']['uvision']['path'][0]
-        assert self.settings.generated_projects_dir == settings_dict['export_dir'][0]
+        assert self.settings.export_location_format == settings_dict['export_dir'][0]
 
     def test_definition(self):
         self.settings.update(settings_dict)


### PR DESCRIPTION
I would like to add some tests too, however due to the way in which the paths are passed around, it would make more sense if these functions returned values rather than changing a value in a dictionary. I tried doing this, and it just opened up another can of worms, since the project object isn't passed to the exporter classes. :cry: 

Anyway, I'll quickly write some tests, and then push that and then this should be good to merge.

new usage:

```yaml
settings:
    # other settings
    export_dir:
        - generated_projects/{workspace}/{target}/{name}/{tool}
```

It currently supports these, and they should all be fairly self explanatory, but nevertheless here they are..:

workspace: workspace name
target: target name
name: project name <- maybe this should be project_name?
tool: tool name

They're defined in the dictionary in project.py on line 493.