### PR TITLE
Fix clean tool

### DIFF
--- a/project_generator/commands/clean.py
+++ b/project_generator/commands/clean.py
@@ -34,4 +34,4 @@ def setup(subparser):
     subparser.add_argument("-f", "--file", help="YAML projects file", default='projects.yaml')
     subparser.add_argument("-p", "--project", required = True, help="Specify which project to be removed")
     subparser.add_argument(
-        "-t", "--tool", required = True, help="Clean project files for specified tool")
+        "-t", "--tool", help="Clean project files")

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -259,8 +259,8 @@ class Project:
             'target': '',       # target
             'template' : '',    # tool template
             'output_type': self.output_types['executable'],           # output type, default - exe
-            'tools_supported': [self.pgen_workspace.settings.DEFAULT_TOOL], # Tools which are supported
-            'singular': True,  # singular project or part of a workspace
+            'tools_supported': [], # Tools which are supported
+            'singular': True,      # singular project or part of a workspace
 
         }
 
@@ -364,6 +364,9 @@ class Project:
     def clean(self, tool):
         tools = []
         if not tool:
+            if len(self.project['tools_supported']) == 0:
+                logging.info("No tool defined.")
+                return -1
             tools = self.project['tools_supported']
         else:
             tools = [tool]
@@ -383,6 +386,9 @@ class Project:
 
         tools = []
         if not tool:
+            if len(self.project['tools_supported']) == 0:
+                logging.error("No tool defined.")
+                return -1
             tools = self.project['tools_supported']
         else:
             tools = [tool]
@@ -412,6 +418,9 @@ class Project:
         """build the project"""
         tools = []
         if not tool:
+            if len(self.project['tools_supported']) == 0:
+                logging.error("No tool defined.")
+                return -1
             tools = self.project['tools_supported']
         else:
             tools = [tool]

--- a/tests/test_commands/test_build.py
+++ b/tests/test_commands/test_build.py
@@ -55,7 +55,7 @@ class TestBuildCommand(TestCase):
             'project_2'])
         result = build.run(args)
 
-        assert result == 0
+        assert result == -1
 
     def test_build_project_uvision_tool(self):
         args = self.parser.parse_args(['build','-f','test_workspace/projects.yaml','-p',

--- a/tests/test_commands/test_export.py
+++ b/tests/test_commands/test_export.py
@@ -61,8 +61,8 @@ class TestExportCommand(TestCase):
         args = self.parser.parse_args(['export','-f','test_workspace/projects.yaml','-p','project_2'])
         result = export.run(args)
 
-        # tools are defined as supported, thus result should be 0
-        assert result == 0
+        # No tools defined
+        assert result == -1
 
     def test_export_one_project_uvision(self):
         export.setup(self.subparser)


### PR DESCRIPTION
This enables to do export/clean without a tool as argument. We check if a project has them defined (tools supported). If not error is printed plus returns error code.