### PR TITLE
Project patches

### DIFF
--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -438,12 +438,12 @@ class Project:
 
         # linker checkup
         if len(self.project['export']['linker_file']) == 0 and self.project['export']['output_type'] == 'exe':
-            raise RuntimeError("Executable - no linker command found.")
+            logging.debug("Executable - no linker command found.")
         elif self.project['export']['output_type'] == 'exe':
             # There might be a situation when there are more linkers. warn user and choose the first one
             if type(self.project['export']['linker_file']) == type(list()):
                 if len(self.project['export']['linker_file']) > 1:
-                    logging.debug("More than one linker command file for the project: %s" % self.name)
+                    logging.debug("More than one linker command files: %s" % self.project['export']['linker_file'])
                 self.project['export']['linker_file'] = self.project['export']['linker_file'][0]
 
     def _set_output_dir_path(self, tool):

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -331,6 +331,7 @@ class Project:
             # None is an error
             if exporter is None:
                 result = -1
+                logging.debug("Tool: %s was not found" % export_tool)
                 continue
 
             self._fill_export_dict(export_tool)
@@ -358,6 +359,7 @@ class Project:
             builder = ToolsSupported().get_tool(build_tool)
             # None is an error
             if builder is None:
+                logging.debug("Tool: %s was not found" % builder)
                 result = -1
                 continue
 

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -265,7 +265,7 @@ class Project:
         for source_file in files:
             if os.path.isdir(source_file):
                 project_dic['source_paths'].append(os.path.normpath(source_file))
-                self._process_source_files(project_dic, [os.path.join(os.path.normpath(source_file), f) for f in os.listdir(
+                Project._process_source_files(project_dic, [os.path.join(os.path.normpath(source_file), f) for f in os.listdir(
                     source_file) if os.path.isfile(os.path.join(os.path.normpath(source_file), f))], group_name)
 
             extension = source_file.split('.')[-1]


### PR DESCRIPTION
- adding debug messages for build/export if tool is not supported (returns -1)
- exe - if no linker, debug message is printed, not a runtime error.