### PR TITLE
Tools - fix extensions - use lower case in tools to get the type

### DIFF
--- a/project_generator/tools/coide.py
+++ b/project_generator/tools/coide.py
@@ -81,7 +81,7 @@ class Coide(Tool, Exporter, Builder):
             if file:
                 extension = file.split(".")[-1]
                 new_file = {
-                    '@path': rel_path + normpath(file), '@name': basename(file), '@type': str(self.file_types[extension])
+                    '@path': rel_path + normpath(file), '@name': basename(file), '@type': str(self.file_types[extension.lower()])
                 }
                 new_data['groups'][group].append(new_file)
 

--- a/project_generator/tools/eclipse.py
+++ b/project_generator/tools/eclipse.py
@@ -62,7 +62,7 @@ class EclipseGnuARM(Tool, Exporter, Builder):
                 # TODO: fix - workaround for windows, seems posixpath does not work
                 source = source.replace('\\', '/')
                 new_file = {"path": join('PARENT-%s-PROJECT_LOC' % new_data['output_dir']['rel_path'], normpath(source)), "name": basename(
-                    source), "type": self.file_types[extension]}
+                    source), "type": self.file_types[extension.lower()]}
                 new_data['groups'][group].append(new_file)
 
     def _get_groups(self, data):

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -102,7 +102,7 @@ class Uvision(Tool, Builder, Exporter):
             if file:
                 extension = file.split(".")[-1]
                 new_file = {"FilePath": rel_path + normpath(file), "FileName": basename(file),
-                            "FileType": self.file_types[extension]}
+                            "FileType": self.file_types[extension.lower()]}
                 new_data['groups'][group].append(new_file)
 
     def _iterate(self, data, expanded_data, rel_path):


### PR DESCRIPTION
Fixes issue with extensions, for instance a file is name.S or name.CPP.