### PR TITLE
Bugfixes and create command from pgen simple

### DIFF
--- a/project_generator/commands/init.py
+++ b/project_generator/commands/init.py
@@ -16,7 +16,7 @@ import os
 import logging
 from ..init_yaml import create_yaml
 
-help = 'Create a project record'
+help = 'Create project records'
 
 
 def run(args):
@@ -25,10 +25,6 @@ def run(args):
     root = os.getcwd()
     directory = root if not args.directory else os.path.normpath(os.path.join(root, args.directory))
     output = directory if not args.output else args.output
-    if args.move:
-        os.chdir(directory)
-        directory = os.path.relpath(directory)
-        output = os.path.relpath(output)
 
     name = os.path.split(directory)[1] if not args.project else args.project
     project = os.path.split(directory)[1] if not args.project else args.project
@@ -41,10 +37,8 @@ def setup(subparser):
     subparser.add_argument(
         '-tar', '--target', action='store', help='Target definition', default = "cortex-m0")
     subparser.add_argument(
-        '-dir', '--directory', action='store', help='Directory selection', default=None)
+        '-dir', '--directory', action='store', help='Directory selection to be scanned', default=None)
     subparser.add_argument(
         '-o', '--output', action='store', help='Generated project files directory')
-    subparser.add_argument(
-        '-move', '--move', action='store_true', help='Move created yaml to source')
     # subparser.add_argument(
     #     '-files', '--files', action='store_true', help='List file names, otherwise only folders are listed', default=None)

--- a/project_generator/commands/init.py
+++ b/project_generator/commands/init.py
@@ -23,9 +23,16 @@ def run(args):
     logging.debug("Generating the records.")
 
     root = os.getcwd()
-    directory = root if not args.directory else os.path.join(root, args.directory)
+    directory = root if not args.directory else os.path.normpath(os.path.join(root, args.directory))
+    output = directory if not args.output else args.output
+    if args.move:
+        os.chdir(directory)
+        directory = os.path.relpath(directory)
+        output = os.path.relpath(output)
+
+    name = os.path.split(directory)[1] if not args.project else args.project
     project = os.path.split(directory)[1] if not args.project else args.project
-    return create_yaml(root, directory, project, args.target.lower(), args.files)
+    return create_yaml(os.path.normpath(directory), name, args.target.lower(), output)
 
 
 def setup(subparser):
@@ -36,4 +43,8 @@ def setup(subparser):
     subparser.add_argument(
         '-dir', '--directory', action='store', help='Directory selection', default=None)
     subparser.add_argument(
-        '-files', '--files', action='store_true', help='List file names, otherwise only folders are listed', default=None)
+        '-o', '--output', action='store', help='Generated project files directory')
+    subparser.add_argument(
+        '-move', '--move', action='store_true', help='Move created yaml to source')
+    # subparser.add_argument(
+    #     '-files', '--files', action='store_true', help='List file names, otherwise only folders are listed', default=None)

--- a/project_generator/commands/list_projects.py
+++ b/project_generator/commands/list_projects.py
@@ -17,7 +17,6 @@ from project_generator_definitions.definitions import ProGenTargets
 
 from ..tools_supported import ToolsSupported
 from ..generate import Generator
-from ..util import unicode_available
 from ..settings import ProjectSettings
 
 help = 'List general pgen data as projects, tools or targets'
@@ -51,4 +50,3 @@ def setup(subparser):
     subparser.add_argument("section", choices = ['targets','tools','projects'],
                            help="What section you would like listed", default='projects')
     subparser.add_argument("-f", "--file", help="YAML projects file")
-    subparser.add_argument("-u", "--no-unicode", help="Use ASCII characters only", action='store_true')

--- a/project_generator/init_yaml.py
+++ b/project_generator/init_yaml.py
@@ -131,7 +131,7 @@ def create_yaml(directory, project_name, board,output_dir):
     for tool, linker in linkers.items():
         if len(linker) > 1:
             # The project directory defined more than one linker for a tool
-            print "\nMultipe linkers found for " + tool + "\n"
+            print("\nMultipe linkers found for " + tool + "\n")
             for i, file in enumerate(linker):
                 print(str(i) + ": " + file)
             answer = raw_input('\nWhich file do you want? ')

--- a/project_generator/init_yaml.py
+++ b/project_generator/init_yaml.py
@@ -147,4 +147,5 @@ def create_yaml(directory, project_name, board,output_dir):
     ret = _generate_file("projects.yaml", projects_yaml)
     if ret < 0: # make sure the first file generated correctly
         return -1
-    _generate_file("project.yaml", project_yaml)
+    ret = _generate_file("project.yaml", project_yaml)
+    return ret

--- a/project_generator/init_yaml.py
+++ b/project_generator/init_yaml.py
@@ -16,104 +16,135 @@ import os
 import yaml
 import logging
 import bisect
+from collections import defaultdict
 
 from .project import FILES_EXTENSIONS
 
-def _determine_tool(linker_ext):
+def _determine_tool(files):
+    """Yields tuples in the form of (linker file, tool the file links for"""
+    for file in files:
+        linker_ext = file.split('.')[-1]
         if "sct" in linker_ext or "lin" in linker_ext:
-            return "uvision"
+            yield (str(file),"uvision")
         elif "ld" in linker_ext:
-            return "make_gcc_arm"
+            yield (str(file),"make_gcc_arm")
         elif "icf" in linker_ext:
-            return "iar_arm"
+            yield (str(file),"iar_arm")
 
 
-def _scan(section, root, directory, extensions, list_files):
-        if section == "sources":
-            data_dict = {}
+def _scan(section, directory, extensions):
+    if section == "sources":
+        data_dict = defaultdict(list)  # sources can have group names, making them a dict
+    else:
+        data_dict = []
+    for dirpath, dirnames, files in os.walk(directory):
+        for filename in files:
+            ext = filename.split('.')[-1]
+            relpath = os.path.relpath(dirpath, directory)
+            if ext in extensions: # Check if the files extension is an acceptable one for this section of yaml
+                if section == "sources":
+                    #get the directory one below root
+                    dir = directory.split(os.path.sep)[-1] if dirpath == directory else dirpath.replace(directory,'').split(os.path.sep)[1]
+                    if relpath not in data_dict[dir]:
+                        # Add the path to the file to this dictionary, with dir as group name
+                        bisect.insort(data_dict[dir], os.path.normpath(relpath))
+                elif section == 'includes':
+                    #get all the folders along the path
+                    dirs = relpath.split(os.path.sep)
+                    for i in range(1, len(dirs)+1):
+                        """ add all combinations of them, because we don't know how they will be referenced in program files
+                            Example - there is a .h file in the path Here\is\include\include.h
+                            We want to catch any possible combo, so add Here, Here\is, and Here\is\include
+
+                        """
+                        data_dict.append(os.path.normpath(os.path.sep.join(dirs[:i])))
+                else:
+                    data_dict.append(os.path.normpath(os.path.join(relpath, filename)))
+    if section == "sources":
+        return dict(data_dict)
+    l = list(set(data_dict))
+    l.sort()
+    return l
+
+def _generate_file(filename,data):
+    logging.debug('Writing the follwoing to %s:\n%s' % (filename, yaml.dump(data)))
+    file = os.path.join(os.getcwd(), filename)
+    if os.path.isfile(file):
+        os.remove(file)
+    try:
+        with open(file, 'w+') as f:
+            f.write(yaml.dump(data, default_flow_style=False))
+    except:
+        logging.error("Unable to open %s for writing!" % file)
+        return -1
+    logging.info("Wrote to file %s" % file)
+
+    return 0
+
+
+def create_yaml(directory, project_name, board,output_dir):
+    # lay out what the common section a project yaml file will look like
+    # The value mapped to by each key are the file extensions that will help us get valid files for each section
+    logging.debug("Project name: %s, Target: %s"%(project_name,board))
+    common_section = {
+        'linker_file': FILES_EXTENSIONS['linker_file'],
+        'sources': FILES_EXTENSIONS['source_files_c'] + FILES_EXTENSIONS['source_files_cpp'] +
+                   FILES_EXTENSIONS['source_files_s'] + FILES_EXTENSIONS['source_files_obj'],
+        'includes': FILES_EXTENSIONS['include_files']
+    }
+
+    # will be written to projects.yaml
+    root = os.path.relpath(directory)
+    projects_yaml = {
+        'projects': {
+            project_name:
+                ['project.yaml']
+        },
+        'settings': {'export_dir': os.path.relpath(output_dir)}
+    }
+
+    # will be written to project.yaml
+    project_yaml = {
+        'common': {},
+        'tool_specific': {}
+    }
+    # iterate over the common section defined above
+    for section, extensions in common_section.items():
+        # look for files in this directory that have the defined extensions, and add them to our project file
+        project_yaml['common'][section] = _scan(section, directory,extensions)
+
+    project_yaml['common']['target'] = [board] # user passes target in command line
+
+    """Find what tool the linker works for - if multiple linkers in this dir, project_yaml['common']['linker_file']
+        is a list. Tools is an iterator"""
+    tools = _determine_tool(project_yaml['common']['linker_file'])
+
+    linkers = {}   # dictionary containing all linker files in the project directory
+
+    # exhaust the iterator and add its yielded values to linkers
+    for (file,tool) in tools:
+        if tool in linkers:
+            linkers[tool].append(file)
         else:
-            data_dict = []
-        for dirpath, dirnames, files in os.walk(directory):
-            for filename in files:
-                ext = filename.split('.')[-1]
-                relpath = os.path.relpath(dirpath, root)
-                if ext in extensions:
-                    if section == "sources":
-                        p = relpath
-                        if list_files:
-                            p = os.path.join(p,filename)
-                        dir = directory.split(os.path.sep)[-1] if dirpath == directory else dirpath.replace(directory,'').split(os.path.sep)[1]
-                        if dir in data_dict and relpath not in data_dict[dir]:
-                            bisect.insort(data_dict[dir], p)
-                        else:
-                            data_dict[dir] = [(p)]
-                    elif section == 'includes':
-                        dirs = relpath.split(os.path.sep)
-                        for i in range(1, len(dirs)+1):
-                            data_dict.append(os.path.sep.join(dirs[:i]))
-                    else:
-                        data_dict.append(os.path.join(relpath, filename))
-        if section == "sources":
-            return data_dict
-        l = list(set(data_dict))
-        l.sort()
-        return l
+            linkers[tool] = [file]
 
-def _generate_file(filename,root,directory,data):
-        logging.debug('Generating yaml file')
-        overwrite = False
-        if os.path.isfile(os.path.join(directory, filename)):
-            print("Project file " +filename+  " already exists")
-            while True:
-                answer = raw_input('Should I overwrite it? (Y/n)')
-                try:
-                    overwrite = answer.lower() in ('y', 'yes')
-                    if not overwrite:
-                        logging.critical('Unable to save project file')
-                        return -1
-                    break
-                except ValueError:
-                    continue
-        if overwrite:
-            with open(os.path.join(root, filename), 'r+') as f:
-                f.write(yaml.dump(data, default_flow_style=False))
+    for tool, linker in linkers.items():
+        if len(linker) > 1:
+            # The project directory defined more than one linker for a tool
+            print "\nMultipe linkers found for " + tool + "\n"
+            for i, file in enumerate(linker):
+                print(str(i) + ": " + file)
+            answer = raw_input('\nWhich file do you want? ')
+            while int(answer) not in range(0,len(linker)):
+                answer = raw_input('Answer not in list. Which file do you want? ')
+            project_yaml['tool_specific'][tool] = {'linker_file': [linkers[tool][int(answer)]]}
         else:
-            with open(os.path.join(root, filename), 'w+') as f:
-                f.write(yaml.dump(data, default_flow_style=False))
+            project_yaml['tool_specific'][tool] = {'linker_file': linker}
 
-def create_yaml(root, directory, project_name, board, files):
-        common_section = {
-            'linker_file': FILES_EXTENSIONS['linker_file'],
-            'sources': FILES_EXTENSIONS['source_files_c'] + FILES_EXTENSIONS['source_files_cpp'] +
-                        FILES_EXTENSIONS['source_files_s'] + FILES_EXTENSIONS['source_files_obj'],
-            'includes': FILES_EXTENSIONS['include_files'],
-            'target': [],
-        }
-        projects_yaml = {
-            'projects': {
-                project_name: ['project.yaml']
-            }
-        }
+    # linker file is now in tool_specific section
+    del project_yaml['common']['linker_file']
 
-        project_yaml = {
-            'common': {},
-            'tool_specific': {}
-        }
-
-        for section in common_section:
-            if len(common_section[section]) > 0:
-                project_yaml['common'][section] = _scan(section, root, directory,common_section[section], files)
-
-        project_yaml['common']['target'] = [board]
-        tool = _determine_tool(str(project_yaml['common']['linker_file']).split('.')[-1])
-        project_yaml['tool_specific'] = {
-            tool: {
-                'linker_file': project_yaml['common']['linker_file']
-            }
-        }
-        _generate_file("projects.yaml", root, directory, projects_yaml)
-        _generate_file("project.yaml", root, directory, project_yaml)
-        return 0
-
-
-
+    ret = _generate_file("projects.yaml", projects_yaml)
+    if ret < 0: # make sure the first file generated correctly
+        return -1
+    _generate_file("project.yaml", project_yaml)

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -262,7 +262,7 @@ class Project:
         use_sources = []
         if type(files) == dict:
             for group_name, sources in files.items():
-                use_sources = sources
+                use_sources += sources
                 use_group_name = group_name
         elif type(files) == list:
             use_sources = files

--- a/project_generator/util.py
+++ b/project_generator/util.py
@@ -69,9 +69,6 @@ def flatten(S):
         return flatten(S[0]) + flatten(S[1:])
     return S[:1] + flatten(S[1:])
 
-def unicode_available():
-    return locale.getdefaultlocale()[1] == 'UTF-8'
-
 def load_yaml_records(yaml_files):
     dictionaries = []
     for yaml_file in yaml_files:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,14 +13,6 @@
 # limitations under the License.
 from project_generator.util import *
 
-def test_unicode_detection():
-    try:
-        print(u'\U0001F648')
-    except UnicodeEncodeError:
-        assert not unicode_available()
-    else:
-        assert unicode_available()
-
 def test_flatten():
     l1 = [['aa', 'bb', ['cc', 'dd', 'ee'], ['ee', 'ff'], 'gg']]
 


### PR DESCRIPTION
I manually cherrypicked the create file.

- For now, I removed move argument, I'll have to look further for that one, seems not working for me when it's true, or at least I dont consider this as valid:

```
projects:
  .:
  - project.yaml
```

- output argument - output is the export dir (I have to rename this reference in the code everywhere, will come as separate PR). Means it should be generated dir, proposals for naming this?
- its still named here init command, not create. We chose init as most of tools which generate files or manage packages, have a command init to create a valid entry point, which this does. Why to rename to create?

@sarahmarshy 