### PR TITLE
Include refactor (include/include files/include paths)

### DIFF
--- a/project_generator/generate.py
+++ b/project_generator/generate.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import yaml
 
 from .settings import ProjectSettings
 from .util import flatten, uniqify, load_yaml_records

--- a/project_generator/init_yaml.py
+++ b/project_generator/init_yaml.py
@@ -67,7 +67,7 @@ def _scan(section, directory, extensions):
     return l
 
 def _generate_file(filename,data):
-    logging.debug('Writing the follwoing to %s:\n%s' % (filename, yaml.dump(data)))
+    logging.debug('Writing the following to %s:\n%s' % (filename, yaml.dump(data)))
     file = os.path.join(os.getcwd(), filename)
     if os.path.isfile(file):
         os.remove(file)

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import yaml
 import shutil
 import logging
 import operator
@@ -21,6 +20,7 @@ import copy
 
 from .tools_supported import ToolsSupported
 from .util import merge_recursive, PartialFormatter, FILES_EXTENSIONS, VALID_EXTENSIONS, FILE_MAP, OUTPUT_TYPES, SOURCE_KEYS, fix_paths
+from .init_yaml import _generate_file
 
 class ProjectWorkspace:
     """ Represents a workspace (multiple projects) """
@@ -524,10 +524,13 @@ class Project:
             if copy:
                 logging.debug("Copying sources to the output directory")
                 self._copy_sources_to_generated_destination()
-            # Print debug info prior exporting
-            logging.debug("Project common data: %s" % self.project['common'])
-            logging.debug("Project tool_specific data: %s" % self.project['tool_specific'])
-            logging.debug("Project export data: %s" % self.project['export'])
+            # dump a log file if debug is enabled
+            if logging.getLogger().isEnabledFor(logging.DEBUG):
+                dump_data = {}
+                dump_data['common'] = self.project['common']
+                dump_data['tool_specific'] = self.project['tool_specific']
+                dump_data['merged'] = self.project['export']
+                _generate_file('%s.progen.log' % self.name, dump_data)
 
             files = exporter(self.project['export'], self.settings).export_project()
             generated_files[export_tool] = files

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -174,7 +174,8 @@ class ProjectTemplateInternal:
 
         internal_template = {
             'source_paths': [],       # [internal] source paths derived from sources
-            'include_files': [],      # [internal] include files - used in the copy function
+            'include_paths': [],      # [internal] include paths derived from sources
+            'include_files': {},      # [internal] include files - used in the copy function
             'source_files_c': {},     # [internal] c source files
             'source_files_cpp': {},   # [internal] c++ source files
             'source_files_s': {},     # [internal] assembly source files
@@ -254,31 +255,46 @@ class Project:
     @staticmethod
     def _process_include_files(source, destination):
         # If it's dic add it , if file, add it to files
+        use_group_name = 'default'
+        use_includes = []
         if 'includes' in source:
-            for include_file in source['includes']:
-                # include might be set to None - empty yaml list
-                if include_file:
-                    if os.path.isfile(include_file):
-                        # file, add it to the list (for copying or if tool requires it)
-                        if not include_file in destination['include_files']:
-                            destination['include_files'].append(os.path.normpath(include_file))
-                        dir_path = os.path.dirname(include_file)
-                    else:
-                        # its a directory
-                        dir_path = include_file
-                        # get all files from dir
-                        include_files = []
-                        try:
-                            for f in os.listdir(dir_path):
-                                if os.path.isfile(os.path.join(os.path.normpath(dir_path), f)) and f.split('.')[-1].lower() in FILES_EXTENSIONS['include_files']:
-                                    include_files.append(os.path.join(os.path.normpath(dir_path), f))
-                        except:
-                            # TODO: catch only those exceptions which are relevant
-                            logging.debug("The includes is not accessible: %s" % include_file)
-                            continue
-                        destination['include_files'] += include_files
-                    if not os.path.normpath(dir_path) in destination['includes']:
-                        destination['includes'].append(os.path.normpath(dir_path))
+            for includes in source['includes']:
+                if type(includes) == dict:
+                    for group_name, include_files in includes.items():
+                        use_includes += include_files
+                        use_group_name = group_name
+                elif type(includes) == list:
+                    use_includes = includes
+                else:
+                    use_includes = [includes]
+
+                if use_group_name not in destination['include_files']:
+                    destination['include_files'][use_group_name] = []
+
+                for include_file in use_includes:
+                    # include might be set to None - empty yaml list
+                    if include_file:
+                        if os.path.isdir(include_file):
+                           # its a directory
+                            dir_path = include_file
+                            # get all files from dir
+                            include_files = []
+                            try:
+                                for f in os.listdir(dir_path):
+                                    if os.path.isfile(os.path.join(os.path.normpath(dir_path), f)) and f.split('.')[-1].lower() in FILES_EXTENSIONS['include_files']:
+                                        include_files.append(os.path.join(os.path.normpath(dir_path), f))
+                            except:
+                                # TODO: catch only those exceptions which are relevant
+                                logging.debug("The includes is not accessible: %s" % include_file)
+                                continue
+                            destination['include_files'][use_group_name] += include_files
+                        else:
+                            # include files are in groups as sources
+                            destination['include_files'][use_group_name].append(os.path.normpath(include_file))
+                            dir_path = os.path.dirname(include_file)
+                        if not os.path.normpath(dir_path) in destination['include_paths']:
+                            destination['include_paths'].append(os.path.normpath(dir_path))
+     
 
     def _process_source_files(self, files, use_group_name='default'):
         use_sources = []
@@ -357,6 +373,15 @@ class Project:
                     continue
         return sources
 
+    def _get_tool_includes(self, tool_keywords):
+        include_files = {}
+        for tool_name in tool_keywords:
+            try:
+                include_files = merge_recursive(include_files, self.project['tool_specific'][tool_name]['include_files'])
+            except KeyError:
+                continue
+        return include_files
+
     def _set_output_dir_path(self, tool, copied):
         if self.settings.export_location_format != self.settings.DEFAULT_EXPORT_LOCATION_FORMAT:
             location_format = self.settings.export_location_format
@@ -400,24 +425,25 @@ class Project:
         self._set_internal_tool_data(tool_keywords)
 
         # Merge common project data with tool specific data
-        self.project['export']['includes'] += self._get_tool_data('includes', tool_keywords)
-        self.project['export']['include_files'] += self._get_tool_data('include_files', tool_keywords)
-        self.project['export']['source_paths'] +=  self._get_tool_data('source_paths', tool_keywords)
+        self.project['export']['source_paths'] += self._get_tool_data('source_paths', tool_keywords)
+        self.project['export']['include_paths'] += self._get_tool_data('include_paths', tool_keywords)
         self.project['export']['linker_file'] =  self.project['export']['linker_file'] or self._get_tool_data('linker_file', tool_keywords)
         self.project['export']['macros'] += self._get_tool_data('macros', tool_keywords)
         self.project['export']['template'] = self._get_tool_data('template', tool_keywords)
 
-        fix_paths(self.project['export'], self.project['export']['output_dir']['rel_path'], list(FILES_EXTENSIONS.keys()) + ['includes', 'source_paths'])
+        fix_paths(self.project['export'], self.project['export']['output_dir']['rel_path'], list(FILES_EXTENSIONS.keys()) + ['include_paths', 'source_paths'])
 
         # misc for tools requires dic merge
         misc = self._get_tool_data('misc', tool_keywords)
         for m in misc:
            self.project['export']['misc'] = merge_recursive(self.project['export']['misc'], m)
 
-        # This is magic with sources as they have groups
+        # This is magic with sources/include_files as they have groups
         tool_sources = self._get_tool_sources(tool_keywords)
         for key in SOURCE_KEYS:
            self.project['export'][key] = merge_recursive(self.project['export'][key], tool_sources[key])
+
+        self.project['export']['include_files'] = merge_recursive(self.project['export']['include_files'], self._get_tool_includes(tool_keywords))
 
         # linker checkup
         if len(self.project['export']['linker_file']) == 0 and self.project['export']['output_type'] == 'exe':

--- a/project_generator/templates/cmakelistgccarm.tmpl
+++ b/project_generator/templates/cmakelistgccarm.tmpl
@@ -41,8 +41,8 @@ enable_language(ASM)
 {% for symbol in macros %}
 set(DEFINES "${DEFINES} -D{{symbol}}"){% endfor %}
 
-# Set includes
-{% for path in includes %}
+# Set include_paths
+{% for path in include_paths %}
 include_directories("{{path}}"){% endfor %}
 
 {#

--- a/project_generator/templates/eclipse.project.tmpl
+++ b/project_generator/templates/eclipse.project.tmpl
@@ -33,5 +33,11 @@
 			<type>1</type>
 			<locationURI>{{file.path}}</locationURI>
 		</link> {% endfor %}{% endfor %}
+		{% for group_name,files in include_files.items() %} {% for file in files %}
+		<link>
+			<name>{{group_name}}/{{file.name}}</name>
+			<type>1</type>
+			<locationURI>{{file.path}}</locationURI>
+		</link> {% endfor %}{% endfor %}
 	</linkedResources>
 </projectDescription>

--- a/project_generator/tools/cmake.py
+++ b/project_generator/tools/cmake.py
@@ -52,9 +52,9 @@ class CMakeGccArm(Tool,Exporter):
             data[key] = paths
         # fix includes
         includes = []
-        for key in data['includes']:
+        for key in data['include_paths']:
             includes.append(getcwd().replace('\\', '/') + '/' + data['output_dir']['path'] + '/' + key.replace('\\', '/'))
-        data['includes'] = includes
+        data['include_paths'] = includes
         data['linker_file'] = getcwd().replace('\\', '/') + '/' + data['output_dir']['path'] + '/' + data['linker_file'].replace('\\', '/')
 
     def export_project(self):

--- a/project_generator/tools/coide.py
+++ b/project_generator/tools/coide.py
@@ -89,11 +89,16 @@ class Coide(Tool, Exporter, Builder):
         """ Get all groups defined """
         groups = []
         for attribute in SOURCE_KEYS:
-                for k, v in self.workspace[attribute].items():
-                    if k == None:
-                        k = 'Sources'
-                    if k not in groups:
-                        groups.append(k)
+            for k, v in self.workspace[attribute].items():
+                if k == None:
+                    k = 'Sources'
+                if k not in groups:
+                    groups.append(k)
+            for k, v in self.workspace['include_files'].items():
+                if k == None:
+                    k = 'Includes'
+                if k not in groups:
+                    groups.append(k)
         return groups
 
     def _iterate(self, data, expanded_data):

--- a/project_generator/tools/coide.py
+++ b/project_generator/tools/coide.py
@@ -47,7 +47,7 @@ class CoIDEdefinitions():
 
 class Coide(Tool, Exporter, Builder):
 
-    file_types = {'cpp': 1, 'c': 1, 's': 1, 'obj': 1, 'lib': 1}
+    file_types = {'cpp': 1, 'c': 1, 's': 1, 'obj': 1, 'lib': 1, 'h': 1}
 
     generated_project = {
         'path': '',
@@ -69,8 +69,9 @@ class Coide(Tool, Exporter, Builder):
     def get_toolchain():
         return 'coide'
 
-    def _expand_data(self, old_data, new_data, attribute, group, rel_path):
-        """ data expansion - uvision needs filename and path separately. """
+    def _expand_data(self, old_data, new_data, attribute, group):
+        """ data expansion - coide needs filename and path separately """
+        # TODO: fix this for include/sources. Do we need it?
         if group == 'Sources':
             old_group = None
         else:
@@ -80,12 +81,12 @@ class Coide(Tool, Exporter, Builder):
             if file:
                 extension = file.split(".")[-1]
                 new_file = {
-                    '@path': rel_path + normpath(file), '@name': basename(file), '@type': str(self.file_types[extension.lower()])
+                    '@path': file, '@name': basename(file), '@type': str(self.file_types[extension.lower()])
                 }
                 new_data['groups'][group].append(new_file)
 
     def _get_groups(self):
-        """ Get all groups defined. """
+        """ Get all groups defined """
         groups = []
         for attribute in SOURCE_KEYS:
                 for k, v in self.workspace[attribute].items():
@@ -95,15 +96,21 @@ class Coide(Tool, Exporter, Builder):
                         groups.append(k)
         return groups
 
-    def _iterate(self, data, expanded_data, rel_path):
-        """ _Iterate through all data, store the result expansion in extended dictionary. """
+    def _iterate(self, data, expanded_data):
+        """ _Iterate through all data, store the result expansion in extended dictionary """
         for attribute in SOURCE_KEYS:
             for k, v in data[attribute].items():
                 if k == None:
                     group = 'Sources'
                 else:
                     group = k
-                self._expand_data(data[attribute], expanded_data, attribute, group, rel_path)
+                self._expand_data(data[attribute], expanded_data, attribute, group)
+        for k, v in data['include_files'].items():
+            if k == None:
+                group = 'Includes'
+            else:
+                group = k
+            self._expand_data(data['include_files'], expanded_data, attribute, group)
 
     def _normalize_mcu_def(self, mcu_def):
         for k, v in mcu_def['Device'].items():
@@ -118,17 +125,6 @@ class Coide(Tool, Exporter, Builder):
             mcu_def['MemoryAreas']['IRAM1'][k] = v[0]
         for k, v in mcu_def['MemoryAreas']['IRAM2'].items():
             mcu_def['MemoryAreas']['IRAM2'][k] = v[0]
-
-    def _fix_paths(self, data, rel_path):
-        data['includes'] = [join(rel_path, normpath(path)) for path in data['includes']]
-
-        for k in data['source_files_lib'].keys():
-            data['source_files_lib'][k] = [join(rel_path,normpath(path)) for path in data['source_files_lib'][k]]
-
-        for k in data['source_files_obj'].keys():
-            data['source_files_obj'][k] = [join(rel_path,normpath(path)) for path in data['source_files_obj'][k]]
-        if data['linker_file']:
-            data['linker_file'] = join(rel_path, normpath(data['linker_file']))
 
     def _coide_option_dictionarize(self, option, key, coide_settings):
         dictionarized = {}
@@ -155,7 +151,7 @@ class Coide(Tool, Exporter, Builder):
 
     def _coproj_set_includepaths(self, coproj_dic, project_dic):
         coproj_dic['Project']['Target']['BuildOption']['Compile']['Includepaths']['Includepath'] = []
-        for include in project_dic['includes']:
+        for include in project_dic['include_paths']:
             coproj_dic['Project']['Target']['BuildOption']['Compile']['Includepaths']['Includepath'].append({'@path': include})
 
     def _coproj_set_linker(self, coproj_dic, project_dic):
@@ -182,8 +178,7 @@ class Coide(Tool, Exporter, Builder):
         expanded_dic['groups'] = {}
         for group in groups:
             expanded_dic['groups'][group] = []
-        self._iterate(self.workspace, expanded_dic, expanded_dic['output_dir']['rel_path'])
-        self._fix_paths(expanded_dic, expanded_dic['output_dir']['rel_path'])
+        self._iterate(self.workspace, expanded_dic)
 
         # generic tool template specified or project
         if expanded_dic['template']:

--- a/project_generator/tools/eclipse.py
+++ b/project_generator/tools/eclipse.py
@@ -24,7 +24,7 @@ from ..util import SOURCE_KEYS
 
 class EclipseGnuARM(Tool, Exporter, Builder):
 
-    file_types = {'cpp': 1, 'c': 1, 's': 1, 'obj': 1, 'lib': 1}
+    file_types = {'cpp': 1, 'c': 1, 's': 1, 'obj': 1, 'lib': 1, 'h': 1}
 
     generated_project = {
         'path': '',
@@ -49,7 +49,7 @@ class EclipseGnuARM(Tool, Exporter, Builder):
     def get_toolchain():
         return 'gcc_arm'
 
-    def _expand_data(self, old_data, new_data, attribute, group, rel_path):
+    def _expand_data(self, old_data, new_data, attribute, group):
         """ data expansion - uvision needs filename and path separately. """
         if group == 'Sources':
             old_group = None
@@ -75,7 +75,7 @@ class EclipseGnuARM(Tool, Exporter, Builder):
                     groups.append(k)
         return groups
 
-    def _iterate(self, data, expanded_data, rel_path):
+    def _iterate(self, data, expanded_data):
         """ Iterate through all data, store the result expansion in extended dictionary. """
         for attribute in SOURCE_KEYS:
             for k, v in data[attribute].items():
@@ -83,7 +83,7 @@ class EclipseGnuARM(Tool, Exporter, Builder):
                     group = 'Sources'
                 else:
                     group = k
-                self._expand_data(data[attribute], expanded_data, attribute, group, rel_path)
+                self._expand_data(data[attribute], expanded_data, attribute, group)
 
     def export_workspace(self):
         logging.debug("Current version of CoIDE does not support workspaces")
@@ -103,7 +103,7 @@ class EclipseGnuARM(Tool, Exporter, Builder):
         expanded_dic['groups'] = {}
         for group in groups:
             expanded_dic['groups'][group] = []
-        self._iterate(self.workspace, expanded_dic, expanded_dic['rel_path'])
+        self._iterate(self.workspace, expanded_dic)
 
         # Project file
         project_path, output['files']['cproj'] = self.gen_file_jinja(

--- a/project_generator/tools/eclipse.py
+++ b/project_generator/tools/eclipse.py
@@ -64,6 +64,7 @@ class EclipseGnuARM(Tool, Exporter, Builder):
                     source), "type": self.file_types[extension.lower()]}
                 new_data['groups'][group].append(new_file)
 
+#TODO: eliminate this duplicate in many tools. Same applies to _iterate
     def _get_groups(self, data):
         """ Get all groups defined. """
         groups = []
@@ -71,6 +72,11 @@ class EclipseGnuARM(Tool, Exporter, Builder):
             for k, v in data[attribute].items():
                 if k == None:
                     k = 'Sources'
+                if k not in groups:
+                    groups.append(k)
+            for k, v in data['include_files'].items():
+                if k == None:
+                    k = 'Includes'
                 if k not in groups:
                     groups.append(k)
         return groups

--- a/project_generator/tools/gccarm.py
+++ b/project_generator/tools/gccarm.py
@@ -103,12 +103,8 @@ class MakefileGccArm(Tool, Exporter):
 
     def process_data_for_makefile(self, project_data):
         #Flatten our dictionary, we don't need groups
-        project_data['source_paths'] = []
         for key in SOURCE_KEYS:
             project_data[key] = list(chain(*project_data[key].values()))
-            project_data['source_paths'].extend([ntpath.split(path)[0] for path in project_data[key]])
-        project_data['source_paths'] = set(project_data['source_paths'])
-
         self._get_libs(project_data)
         self._parse_specific_options(project_data)
 

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -110,7 +110,7 @@ class IAREmbeddedWorkbenchProject:
         index_option = self._get_option(ewp_dic[index_iccarm]['data']['option'], 'CCDefines')
         self._set_multiple_option(ewp_dic[index_iccarm]['data']['option'][index_option], project_dic['macros'])
         index_option = self._get_option(ewp_dic[index_iccarm]['data']['option'], 'CCIncludePath2')
-        self._set_multiple_option(ewp_dic[index_iccarm]['data']['option'][index_option], project_dic['includes'])
+        self._set_multiple_option(ewp_dic[index_iccarm]['data']['option'][index_option], project_dic['include_paths'])
 
         iccarm_dic = ewp_dic[index_iccarm]['data']['option']
         self._ewp_flags_set(iccarm_dic, project_dic, 'cx_flags', self.FLAG_TO_IAR['cxx_flags'])
@@ -259,17 +259,6 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
     def get_toolchain():
         return 'iar'
 
-    def _get_groups(self, data):
-        """ Get all groups defined """
-        groups = []
-        for attribute in SOURCE_KEYS:
-            for k, v in data[attribute].items():
-                if k == None:
-                    k = 'Sources'
-                if k not in groups:
-                    groups.append(k)
-        return groups
-
     def _find_target_core(self, data):
         """ Sets Target core """
         for k, v in self.core_dic.items():
@@ -302,7 +291,7 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
 
     def _fix_paths(self, data):
         """ All paths needs to be fixed - add PROJ_DIR prefix + normalize """
-        data['includes'] = [join('$PROJ_DIR$', path) for path in data['includes']]
+        data['include_paths'] = [join('$PROJ_DIR$', path) for path in data['include_paths']]
 
         if data['linker_file']:
             data['linker_file'] = join('$PROJ_DIR$', data['linker_file'])
@@ -313,6 +302,10 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                 if k not in data['groups']:
                     data['groups'][k] = []
                 data['groups'][k].extend([join('$PROJ_DIR$', file) for file in v])
+        for k,v in data['include_files'].items():
+            if k not in data['groups']:
+                data['groups'][k] = []
+            data['groups'][k].extend([join('$PROJ_DIR$', file) for file in v])
 
     def _get_option(self, settings, find_key):
         """ Return index for provided key """

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -142,6 +142,11 @@ class Uvision(Tool, Builder, Exporter):
                     k = 'Sources'
                 if k not in groups:
                     groups.append(k)
+            for k, v in data['include_files'].items():
+                if k == None:
+                    k = 'Includes'
+                if k not in groups:
+                    groups.append(k)
         return groups
 
     def _normalize_mcu_def(self, mcu_def):

--- a/tests/test_commands/simple_project.py
+++ b/tests/test_commands/simple_project.py
@@ -1,7 +1,7 @@
 project_1_yaml = {
     'common': {
-        'sources': ['test_workspace/main.cpp'],
-        'includes': ['test_workspace/header1.h'],
+        'sources': {'sources': ['test_workspace/main.cpp']},
+        'includes': {'includes': ['test_workspace/header1.h']},
         'macros': ['MACRO1', 'MACRO2'],
         'target': ['mbed-lpc1768'],
         'core': ['core1'],

--- a/tests/test_tools/simple_project.py
+++ b/tests/test_tools/simple_project.py
@@ -1,7 +1,7 @@
 project_1_yaml = {
     'common': {
-        'sources': ['sources/main.cpp'],
-        'includes': ['includes/header1.h'],
+        'sources': {'sources': ['sources/main.cpp']},
+        'includes': {'includes': ['includes/header1.h']},
         'target': ['mbed-lpc1768'],
         'linker_file': ['linker_script'],
         'debugger': ['j-link'],
@@ -44,7 +44,6 @@ project_1_yaml = {
                 'ld_flags': ['ld_flag_test', 'ld_flag_test2'],
                 'common_flags': ['common_flag_test', 'common_flag_test2'],
                 'standard_libraries': ['standard_libraries_test'],
-                'optimization': ['O1'],
             },
         }
     }


### PR DESCRIPTION
Fixes #309 and #310

Same as for sources, includes can be grouped. Includes used to be on it's own, now they follow what is for sources. There are include paths, include_files with groups.

I propose to add include files to the project tree by default. If not desired, we can add an option for generate to exclude them to be shown there (as it is currently).