### PR TITLE
Provide a way to set root

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Project generator currently generaters projects for the following tools (IDE, Ma
  - CoIDE (GCC ARM)
  - Eclipse (Makefile with GCC ARM)
  - Sublime (Makefile with GCC ARM)
- - Visual studio (Makegile with GCC ARM)
+ - Visual studio (Makefile with GCC ARM)
 
 We appreciate any help and you are more than welcome to send a pull request or create a new issue in this repository.
 The plan is to support as many IDE as possible , same applies for targets/MCU.

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -32,8 +32,10 @@ class ProjectWorkspace:
         self.workspace_settings = workspace_settings
         self.generated_files = {}
 
-    def generate(self, tool, copy):
-        """ Exports workspace """
+    def generate(self, tool, copied=False, copy=False):
+        """ Generates a workspace """
+
+        # copied - already done by external script, copy - do actual copy
 
         tools = []
         if not tool:
@@ -84,7 +86,7 @@ class ProjectWorkspace:
                     project.project['common']['export_dir'] = location
                 # Merge all dics, copy sources if required, correct output dir. This happens here
                 # because we need tool to set proper path (tool might be used as string template)
-                project._fill_export_dict(export_tool, copy)
+                project._fill_export_dict(export_tool, copied)
 
                 if copy:
                     project._copy_sources_to_generated_destination()
@@ -502,7 +504,7 @@ class Project:
                 shutil.rmtree(path)
         return 0
 
-    def generate(self, tool, copy):
+    def generate(self, tool, copied=False, copy=False):
         """ Generates a project """
 
         tools = self._validate_tools(tool)
@@ -520,7 +522,7 @@ class Project:
                 logging.debug("Tool: %s was not found" % export_tool)
                 continue
 
-            self._fill_export_dict(export_tool, copy)
+            self._fill_export_dict(export_tool, copied)
             if copy:
                 logging.debug("Copying sources to the output directory")
                 self._copy_sources_to_generated_destination()

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -341,10 +341,10 @@ class Project:
         return tools
 
     @staticmethod
-    def _generate_output_dir(path):
+    def _generate_output_dir(settings, path):
         """ This is a separate function, so that it can be more easily tested """
 
-        relpath = os.path.relpath(os.getcwd(),path)
+        relpath = os.path.relpath(settings.root,path)
         count = relpath.count(os.sep) + 1
 
         return relpath+os.path.sep, count
@@ -406,7 +406,7 @@ class Project:
             self.project['export']['output_dir']['rel_path'] = ''
             self.project['export']['output_dir']['rel_count'] = 0
         else:
-            self.project['export']['output_dir']['rel_path'], self.project['export']['output_dir']['rel_count'] = self._generate_output_dir(path)
+            self.project['export']['output_dir']['rel_path'], self.project['export']['output_dir']['rel_count'] = self._generate_output_dir(self.settings, path)
 
     def _fill_export_dict(self, tool, copied=False):
         tool_keywords = []
@@ -471,17 +471,17 @@ class Project:
             else:
                 files.append(self.project['export'][key])
 
-        destination = os.path.join(os.getcwd(), self.project['export']['output_dir']['path'])
+        destination = os.path.join(self.settings.root, self.project['export']['output_dir']['path'])
         if os.path.exists(destination):
             shutil.rmtree(destination)
         for item in files:
-            s = os.path.join(os.getcwd(), item)
+            s = os.path.join(self.settings.root, item)
             d = os.path.join(destination, item)
             if os.path.isdir(s):
                 shutil.copytree(s,d)
             else:
                 if not os.path.exists(os.path.dirname(d)):
-                    os.makedirs(os.path.join(os.getcwd(), os.path.dirname(d)))
+                    os.makedirs(os.path.join(self.settings.root, os.path.dirname(d)))
                 shutil.copy2(s,d)
 
     def clean(self, tool):

--- a/project_generator/settings.py
+++ b/project_generator/settings.py
@@ -38,6 +38,7 @@ class ProjectSettings:
         self.paths['gcc'] = os.environ.get('ARM_GCC_PATH') or ''
 
         self.export_location_format = self.DEFAULT_EXPORT_LOCATION_FORMAT
+        self.root = os.getcwd()
 
     def update(self, settings):
         if settings:
@@ -53,8 +54,6 @@ class ProjectSettings:
                 self.export_location_format = normpath(settings['export_dir'][0])
             if 'root' in settings:
                 self.root = normpath(settings['root'][0])
-            else:
-                self.root = os.getcwd()
 
     def get_env_settings(self, env_set):
         return self.paths[env_set]

--- a/project_generator/settings.py
+++ b/project_generator/settings.py
@@ -51,6 +51,10 @@ class ProjectSettings:
 
             if 'export_dir' in settings:
                 self.export_location_format = normpath(settings['export_dir'][0])
+            if 'root' in settings:
+                self.root = normpath(settings['root'][0])
+            else:
+                self.root = os.getcwd()
 
     def get_env_settings(self, env_set):
         return self.paths[env_set]

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -19,6 +19,7 @@ import logging
 import xmltodict
 import copy
 
+from os import getcwd
 from os.path import basename, join, normpath
 from collections import OrderedDict
 from project_generator_definitions.definitions import ProGenDef

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -20,7 +20,6 @@ import xmltodict
 import copy
 
 from os.path import basename, join, normpath
-from os import getcwd
 from collections import OrderedDict
 from project_generator_definitions.definitions import ProGenDef
 
@@ -233,9 +232,9 @@ class Uvision(Tool, Builder, Exporter):
             # get relpath for project and inject it into workspace
             path_project = os.path.dirname(project['files']['uvproj'])
             path_workspace = os.path.dirname(self.workspace['settings']['path'] + '\\')
-            destination = os.path.join(os.path.relpath(os.getcwd(), path_project), project['files']['uvproj'])
+            destination = os.path.join(os.path.relpath(self.env_settings.root, path_project), project['files']['uvproj'])
             if path_project != path_workspace:
-                destination = os.path.join(os.path.relpath(os.getcwd(), path_workspace), project['files']['uvproj'])
+                destination = os.path.join(os.path.relpath(self.env_settings.root, path_workspace), project['files']['uvproj'])
             uvmpw_dic['ProjectWorkspace']['project'].append({'PathAndName': destination})
 
         # generate the file
@@ -358,7 +357,7 @@ class Uvision(Tool, Builder, Exporter):
 
     def build_project(self):
         # > UV4 -b [project_path]
-        path = join(os.getcwd(), self.workspace['files']['uvproj'])
+        path = join(self.env_settings.root, self.workspace['files']['uvproj'])
         if path.split('.')[-1] != 'uvproj' and path.split('.')[-1] != 'uvprojx':
             path = path + '.uvproj'
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -19,6 +19,7 @@ from unittest import TestCase
 
 from project_generator.project import Project
 from project_generator.generate import Generator
+from project_generator.settings import ProjectSettings
 
 project_1_yaml = {
     'common': {
@@ -44,7 +45,7 @@ projects_yaml = {
 }
 
 def test_output_directory_formatting():
-    path, depth = Project._generate_output_dir('aaa/bbb/cccc/ddd/eee/ffff/ggg')
+    path, depth = Project._generate_output_dir(ProjectSettings(),'aaa/bbb/cccc/ddd/eee/ffff/ggg')
 
     assert depth == 7
     assert os.path.normpath(path) == os.path.normpath('../../../../../../../')


### PR DESCRIPTION
Root can be set via settings in the projects.yaml file, plus I did a small change here during testing. 

For external scripts, might be useful to do own copy, where they do all the magic they need, all they want to generate, using relative paths within generated folder. thus generate has now 2 arguments (copied and copy-I should name it do_copy).