### PR TITLE
Fix project template

### DIFF
--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -199,6 +199,8 @@ class Project:
     def __init__(self, name, project_dicts, settings, workspace_name=None):
         """ Initialise a project with a yaml file """
 
+        assert type(project_dicts) is list, "Project records/dics must be a list" % project_dicts 
+
         self.settings = settings
         self.name = name
         self.workspace_name = workspace_name

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -226,8 +226,7 @@ class Project:
                             # if dict does not exist, we initialize it
                             bool(self.project['tool_specific'][tool_name])
                         except KeyError:
-                            self.project['tool_specific'][tool_name] = ProjectTemplate._get_tool_specific_data_template()
-                            self.project['tool_specific'][tool_name].update(ProjectTemplate._get_common_data_template())
+                            self.project['tool_specific'][tool_name] = ProjectTemplate.get_project_template(self.name, OUTPUT_TYPES['exe'])
                         self._set_project_attributes(tool_name, self.project['tool_specific'][tool_name], project_data['tool_specific'])
         self.generated_files = {}
 

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -218,6 +218,10 @@ class Project:
                     self._set_project_attributes('common', self.project['common'], project_data)
                 if 'tool_specific' in project_data:
                     for tool_name, tool_settings in project_data['tool_specific'].items():
+                        # if there's no valid tool name, skip that yaml file and report to a user
+                        if tool_name not in ToolsSupported().get_supported():
+                            logging.error("Project data %s contain non-valid tool: %s" % (project_data, tool_name))
+                            continue
                         try:
                             # if dict does not exist, we initialize it
                             bool(self.project['tool_specific'][tool_name])
@@ -241,7 +245,10 @@ class Project:
                     elif type(destination[attribute]) is dict:
                         destination[attribute].update(data)
                     else:
-                        destination[attribute] = data[0]
+                        if type(data) is list:
+                            destination[attribute] = data[0]
+                        else:
+                            destination[attribute] = data
 
     def _set_internal_common_data(self):
         # process here includes, sources and set all internal data related to them

--- a/tests/test_projecttemplate.py
+++ b/tests/test_projecttemplate.py
@@ -1,0 +1,98 @@
+# Copyright 2015 0xc0170
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from project_generator.project import Project, ProjectTemplate
+from project_generator.settings import ProjectSettings
+
+class TestProjectTemplate:
+
+    def setup(self):
+        # set common and tool specific options
+        self.project_dic = {}
+        self.project_dic['common'] = ProjectTemplate().get_project_template()
+        self.project_dic['tool_specific'] = ProjectTemplate().get_project_template()
+
+    def testDefaultCtor(self):
+        assert self.project_dic['common']['name'] == 'Default'
+        assert self.project_dic['common']['output_type'] == 'exe'
+        assert self.project_dic['common']['debugger'] == None
+        assert self.project_dic['common']['build_dir'] == 'build'
+
+    def testProjectCommon(self):
+        self.project_dic['common']['name'] = 'test_name'
+        self.project_dic['common']['build_dir'] = 'test_build'
+        self.project_dic['common']['debugger'] = 'test_debugger'
+        self.project_dic['common']['export_dir'] = 'test_export'
+        self.project_dic['common']['target'] = 'test_target'
+        self.project_dic['common']['output_type'] = 'test_lib'
+        self.project_dic['common']['tools_supported'] = ['test_tool']
+        self.project_dic['common']['includes'] = ['test_export']
+        self.project_dic['common']['linker_file'] = 'test_linker'
+        self.project_dic['common']['macros'] = ['test_macro']
+        self.project_dic['common']['misc'] = {'test_misc': 'test_value'}
+        self.project_dic['common']['template'] = 'test_template'
+
+        project = Project('test_name', [self.project_dic], ProjectSettings())
+
+        assert project.project['common']['name'] == 'test_name'
+        assert project.project['common']['build_dir'] == 'test_build'
+        assert project.project['common']['debugger'] == 'test_debugger'
+        assert project.project['common']['export_dir'] == 'test_export'
+        assert project.project['common']['target'] == 'test_target'
+        assert project.project['common']['output_type'] == 'test_lib'
+        assert project.project['common']['tools_supported'][0] == 'test_tool'
+        assert self.project_dic['common']['includes'][0] == 'test_export'
+        assert self.project_dic['common']['linker_file'] == 'test_linker'
+        assert self.project_dic['common']['macros'][0] == 'test_macro'
+        assert self.project_dic['common']['misc']['test_misc'] == 'test_value'
+        assert self.project_dic['common']['template'] == 'test_template'
+
+    def testProjectToolSpecificNonvalid(self):
+        project = Project('test_name', [self.project_dic], ProjectSettings())
+
+        # non valid - no tool specified, tool specific should be empty array
+        assert not project.project['tool_specific']
+
+    def testProjectToolspecificValid(self):
+        self.project_dic['tool_specific'] = {}
+        self.project_dic['tool_specific']['uvision'] = {}
+        self.project_dic['tool_specific']['uvision']['build_dir'] = 'test_build'
+        self.project_dic['tool_specific']['uvision']['debugger'] = 'test_debugger'
+        self.project_dic['tool_specific']['uvision']['export_dir'] = 'test_export'
+        self.project_dic['tool_specific']['uvision']['target'] = 'test_target'
+        self.project_dic['tool_specific']['uvision']['output_type'] = 'test_lib'
+        self.project_dic['tool_specific']['uvision']['tools_supported'] = ['test_tool']
+        self.project_dic['tool_specific']['uvision']['includes'] = ['test_export']
+        self.project_dic['tool_specific']['uvision']['linker_file'] = 'test_linker'
+        self.project_dic['tool_specific']['uvision']['macros'] = ['test_macro']
+        self.project_dic['tool_specific']['uvision']['misc'] = {'test_misc': 'test_value'}
+        self.project_dic['tool_specific']['uvision']['template'] = 'test_template'
+
+        project = Project('test_name', [self.project_dic], ProjectSettings())
+
+        # Tool specific should be same as common, we can override anything there
+        assert project.project['tool_specific']['uvision']['name'] == 'test_name'
+        assert project.project['tool_specific']['uvision']['build_dir'] == 'test_build'
+        assert project.project['tool_specific']['uvision']['debugger'] == 'test_debugger'
+        assert project.project['tool_specific']['uvision']['export_dir'] == 'test_export'
+        assert project.project['tool_specific']['uvision']['target'] == 'test_target'
+        assert project.project['tool_specific']['uvision']['output_type'] == 'test_lib'
+        assert project.project['tool_specific']['uvision']['tools_supported'][0] == 'test_tool'
+        assert self.project_dic['tool_specific']['uvision']['includes'][0] == 'test_export'
+        assert self.project_dic['tool_specific']['uvision']['linker_file'] == 'test_linker'
+        assert self.project_dic['tool_specific']['uvision']['macros'][0] == 'test_macro'
+        assert self.project_dic['tool_specific']['uvision']['misc']['test_misc'] == 'test_value'
+        assert self.project_dic['tool_specific']['uvision']['template'] == 'test_template'


### PR DESCRIPTION
Fix #325 

Test was written first which was failing, added bugfixes. This now allows a user to do:

```
project_dic = {}
project_dic['common'] = ProjectTemplate().get_project_template()
project_dic['tool_specific'] = {}
project_dic['tool_specific']['iar'] = ProjectTemplate().get_project_template()
# fill in data now
project_dic['common']['sources'] = sources
```

Look at the test to get more info