### PR TITLE
Add ULINK Pro to uvision tool

### DIFF
--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -49,7 +49,15 @@ class uVisionDefinitions():
             'Utilities': {
                 'Flash2': 'Segger\JL2CM3.dll',
             },
-        }
+        },
+	'ulink-pro': {
+            'TargetDlls': {
+                'Driver': 'BIN\\ULP2CM3.dll',
+            },
+            'Utilities': {
+                'Flash2': 'BIN\\ULP2CM3.dll',
+            },
+	}
     }
 
 


### PR DESCRIPTION
This patch adds ULINK Pro to the debuggers supported by uvision.

Signed-off-by: Vincenzo Frascino <vincenzo.frascino@arm.com>