### PR TITLE
Properly merge misc settings from separate files

### DIFF
--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -242,7 +242,7 @@ class Project:
                         else:
                             destination[attribute].append(data)
                     elif type(destination[attribute]) is dict:
-                        destination[attribute].update(data)
+                        destination[attribute] = merge_recursive(destination[attribute], data)
                     else:
                         if type(data) is list:
                             destination[attribute] = data[0]


### PR DESCRIPTION
Misc settings defined in separate files overwrite each other rather
than getting merged.  This is because the dictionary handling
overwrites duplicate entries rather than mering them.  This patch
fixes that problem by merging entries with _merge_dict.