### PR TITLE
Test project class - adding more members tests

### DIFF
--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -312,8 +312,8 @@ class Project:
         use_sources = []
         if type(files) == dict:
             for group_name, sources in files.items():
-                use_sources += sources
-                use_group_name = group_name
+                # process each group name as separate entity
+                self._process_source_files(sources, group_name)
         elif type(files) == list:
             use_sources = files
         else:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -43,7 +43,10 @@ project_2_yaml = {
             'sources_dict' : ['test_workspace/file2.cpp'],
             'sources_dict2' : ['test_workspace/file3.cpp']
         },
-        'includes': ['test_workspace/header2.h'],
+        'includes':  {
+            'include_dict' : ['test_workspace/header2.h'],
+            'include_dict2' : ['test_workspace/header3.h']
+        },
         'macros': ['MACRO2_1', 'MACRO2_2'],
     }
 }
@@ -94,6 +97,8 @@ class TestProjectYAML(TestCase):
             pass
         with open(os.path.join(os.getcwd(), 'test_workspace/header2.h'), 'wt') as f:
             pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/header3.h'), 'wt') as f:
+            pass
         with open(os.path.join(os.getcwd(), 'test_workspace/linker.ld'), 'wt') as f:
             pass
 
@@ -115,7 +120,13 @@ class TestProjectYAML(TestCase):
     def test_project_attributes(self):
         self.project._fill_export_dict('uvision')
         assert self.project.project['export']['macros'] == project_1_yaml['common']['macros'] + project_2_yaml['common']['macros'] 
-        assert self.project.project['export']['includes'] == project_1_yaml['common']['includes'] + project_2_yaml['common']['includes']
+        assert list(self.project.project['export']['include_files'].keys()) == ['default'] + list(project_2_yaml['common']['includes'].keys())
+
+        # no c or asm files, empty dics
+        assert self.project.project['export']['source_files_c'] == dict()
+        assert self.project.project['export']['source_files_s'] == dict()
+        # source groups should be equal
+        assert self.project.project['export']['source_files_cpp'].keys() == merge_recursive(project_1_yaml['common']['sources'], project_2_yaml['common']['sources']).keys()
 
     def test_copy(self):
         # test copy method which should copy all files to generated project dir by default
@@ -145,6 +156,8 @@ class TestProjectDict(TestCase):
             pass
         with open(os.path.join(os.getcwd(), 'test_workspace/header2.h'), 'wt') as f:
             pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/header3.h'), 'wt') as f:
+            pass
         with open(os.path.join(os.getcwd(), 'test_workspace/linker.ld'), 'wt') as f:
             pass
 
@@ -160,7 +173,8 @@ class TestProjectDict(TestCase):
     def test_project_attributes(self):
         self.project._fill_export_dict('uvision')
         assert self.project.project['export']['macros'] == project_1_yaml['common']['macros'] + project_2_yaml['common']['macros'] 
-        assert self.project.project['export']['includes'] == project_1_yaml['common']['includes'] + project_2_yaml['common']['includes']
+        assert list(self.project.project['export']['include_files'].keys()) == ['default'] + list(project_2_yaml['common']['includes'].keys())
+
         # no c or asm files, empty dics
         assert self.project.project['export']['source_files_c'] == dict()
         assert self.project.project['export']['source_files_s'] == dict()
@@ -173,7 +187,7 @@ class TestProjectDict(TestCase):
         for dic in self.project.project['export']['sources']:
             for k, v in dic.items():
                 source_groups.append(k)
-        assert source_groups == project_1_yaml['common']['sources'].keys() + project_2_yaml['common']['sources'].keys()
+        assert source_groups == list(project_1_yaml['common']['sources'].keys()) + list(project_2_yaml['common']['sources'].keys())
 
     def test_copy(self):
         # test copy method which should copy all files to generated project dir by default

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -20,10 +20,12 @@ from unittest import TestCase
 from project_generator.project import Project
 from project_generator.generate import Generator
 from project_generator.settings import ProjectSettings
+from project_generator.util import merge_recursive
 
 project_1_yaml = {
     'common': {
-        'sources': ['test_workspace/main.cpp'],
+        'sources': { 'sources_dict' : ['test_workspace/main.cpp']
+        },
         'includes': ['test_workspace/header1.h'],
         'macros': ['MACRO1', 'MACRO2'],
         'target': ['target1'],
@@ -35,9 +37,18 @@ project_1_yaml = {
     }
 }
 
+project_2_yaml = {
+    'common': {
+        'sources': { 'sources_dict' : ['test_workspace/file2.cpp']
+        },
+        'includes': ['test_workspace/header2.h'],
+        'macros': ['MACRO2_1', 'MACRO2_2'],
+    }
+}
+
 projects_yaml = {
     'projects': {
-        'project_1' : ['test_workspace/project_1.yaml']
+        'project_1' : ['test_workspace/project_1.yaml', 'test_workspace/project_2.yaml']
     },
     'settings' : {
         'export_dir': ['projects/{tool}_{target}/{project_name}']
@@ -60,6 +71,8 @@ class TestProject(TestCase):
         # write project file
         with open(os.path.join(os.getcwd(), 'test_workspace/project_1.yaml'), 'wt') as f:
             f.write(yaml.dump(project_1_yaml, default_flow_style=False))
+        with open(os.path.join(os.getcwd(), 'test_workspace/project_2.yaml'), 'wt') as f:
+            f.write(yaml.dump(project_2_yaml, default_flow_style=False))
         # write projects file
         with open(os.path.join(os.getcwd(), 'test_workspace/projects.yaml'), 'wt') as f:
             f.write(yaml.dump(projects_yaml, default_flow_style=False))
@@ -71,7 +84,11 @@ class TestProject(TestCase):
         # create 3 files to test project
         with open(os.path.join(os.getcwd(), 'test_workspace/main.cpp'), 'wt') as f:
             pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/file2.cpp'), 'wt') as f:
+            pass
         with open(os.path.join(os.getcwd(), 'test_workspace/header1.h'), 'wt') as f:
+            pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/header2.h'), 'wt') as f:
             pass
         with open(os.path.join(os.getcwd(), 'test_workspace/linker.ld'), 'wt') as f:
             pass
@@ -90,6 +107,12 @@ class TestProject(TestCase):
 
     def test_name(self):
         assert self.project.name == 'project_1'
+
+    def test_project_attributes(self):
+        self.project._fill_export_dict('uvision')
+        assert self.project.project['export']['macros'] == project_1_yaml['common']['macros'] + project_2_yaml['common']['macros'] 
+        assert self.project.project['export']['includes'] == project_1_yaml['common']['includes'] + project_2_yaml['common']['includes']
+        assert self.project.project['export']['sources'] == merge_recursive(project_1_yaml['common']['sources'], project_2_yaml['common']['sources'])
 
     def test_copy(self):
         # test copy method which should copy all files to generated project dir by default

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -39,7 +39,9 @@ project_1_yaml = {
 
 project_2_yaml = {
     'common': {
-        'sources': { 'sources_dict' : ['test_workspace/file2.cpp']
+        'sources': { 
+            'sources_dict' : ['test_workspace/file2.cpp'],
+            'sources_dict2' : ['test_workspace/file3.cpp']
         },
         'includes': ['test_workspace/header2.h'],
         'macros': ['MACRO2_1', 'MACRO2_2'],
@@ -86,6 +88,8 @@ class TestProjectYAML(TestCase):
             pass
         with open(os.path.join(os.getcwd(), 'test_workspace/file2.cpp'), 'wt') as f:
             pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/file3.cpp'), 'wt') as f:
+            pass
         with open(os.path.join(os.getcwd(), 'test_workspace/header1.h'), 'wt') as f:
             pass
         with open(os.path.join(os.getcwd(), 'test_workspace/header2.h'), 'wt') as f:
@@ -112,7 +116,6 @@ class TestProjectYAML(TestCase):
         self.project._fill_export_dict('uvision')
         assert self.project.project['export']['macros'] == project_1_yaml['common']['macros'] + project_2_yaml['common']['macros'] 
         assert self.project.project['export']['includes'] == project_1_yaml['common']['includes'] + project_2_yaml['common']['includes']
-        assert self.project.project['export']['sources'] == merge_recursive(project_1_yaml['common']['sources'], project_2_yaml['common']['sources'])
 
     def test_copy(self):
         # test copy method which should copy all files to generated project dir by default
@@ -136,6 +139,8 @@ class TestProjectDict(TestCase):
             pass
         with open(os.path.join(os.getcwd(), 'test_workspace/file2.cpp'), 'wt') as f:
             pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/file3.cpp'), 'wt') as f:
+            pass
         with open(os.path.join(os.getcwd(), 'test_workspace/header1.h'), 'wt') as f:
             pass
         with open(os.path.join(os.getcwd(), 'test_workspace/header2.h'), 'wt') as f:
@@ -156,7 +161,19 @@ class TestProjectDict(TestCase):
         self.project._fill_export_dict('uvision')
         assert self.project.project['export']['macros'] == project_1_yaml['common']['macros'] + project_2_yaml['common']['macros'] 
         assert self.project.project['export']['includes'] == project_1_yaml['common']['includes'] + project_2_yaml['common']['includes']
-        assert self.project.project['export']['sources'] == merge_recursive(project_1_yaml['common']['sources'], project_2_yaml['common']['sources'])
+        # no c or asm files, empty dics
+        assert self.project.project['export']['source_files_c'] == dict()
+        assert self.project.project['export']['source_files_s'] == dict()
+        # source groups should be equal
+        assert self.project.project['export']['source_files_cpp'].keys() == merge_recursive(project_1_yaml['common']['sources'], project_2_yaml['common']['sources']).keys()
+
+    def test_sources_groups(self):
+        self.project._fill_export_dict('uvision')
+        source_groups = []
+        for dic in self.project.project['export']['sources']:
+            for k, v in dic.items():
+                source_groups.append(k)
+        assert source_groups == project_1_yaml['common']['sources'].keys() + project_2_yaml['common']['sources'].keys()
 
     def test_copy(self):
         # test copy method which should copy all files to generated project dir by default

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -61,7 +61,7 @@ def test_output_directory_formatting():
     assert depth == 7
     assert os.path.normpath(path) == os.path.normpath('../../../../../../../')
 
-class TestProject(TestCase):
+class TestProjectYAML(TestCase):
 
     """test things related to the Project class"""
 
@@ -122,3 +122,48 @@ class TestProject(TestCase):
     def test_set_output_dir_path(self):
         self.project._fill_export_dict('uvision')
         assert self.project.project['export']['output_dir']['path'] == os.path.join('projects', 'uvision_target1','project_1')
+
+class TestProjectDict(TestCase):
+
+    """test things related to the Project class, using python dicts"""
+
+    def setUp(self):
+        if not os.path.exists('test_workspace'):
+            os.makedirs('test_workspace')
+
+        # create 3 files to test project
+        with open(os.path.join(os.getcwd(), 'test_workspace/main.cpp'), 'wt') as f:
+            pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/file2.cpp'), 'wt') as f:
+            pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/header1.h'), 'wt') as f:
+            pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/header2.h'), 'wt') as f:
+            pass
+        with open(os.path.join(os.getcwd(), 'test_workspace/linker.ld'), 'wt') as f:
+            pass
+
+        self.project = Project('project_1', [project_1_yaml, project_2_yaml], ProjectSettings())
+
+    def tearDown(self):
+        # remove created directory
+        shutil.rmtree('test_workspace', ignore_errors=True)
+
+    def test_name(self):
+        assert self.project.name == 'project_1'
+
+    def test_project_attributes(self):
+        self.project._fill_export_dict('uvision')
+        assert self.project.project['export']['macros'] == project_1_yaml['common']['macros'] + project_2_yaml['common']['macros'] 
+        assert self.project.project['export']['includes'] == project_1_yaml['common']['includes'] + project_2_yaml['common']['includes']
+        assert self.project.project['export']['sources'] == merge_recursive(project_1_yaml['common']['sources'], project_2_yaml['common']['sources'])
+
+    def test_copy(self):
+        # test copy method which should copy all files to generated project dir by default
+        self.project._fill_export_dict('uvision', True)
+        self.project._copy_sources_to_generated_destination()
+
+    def test_set_output_dir_path(self):
+        self.project._fill_export_dict('uvision')
+        # we use default one in this class
+        assert self.project.project['export']['output_dir']['path'] == os.path.join('generated_projects', 'uvision_project_1')


### PR DESCRIPTION
Adding new test class to test Project with python dicts.

We should test that all members of the project are as they should be, I am now focusing on sources, macros, includes. That they have tested groups, merging various groups. 

#334 - this test reproduces this bug, will fix it