### PR TITLE
project - sort source files alphabetically within the group and source key

### DIFF
--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -470,7 +470,12 @@ class Project:
         # This is magic with sources/include_files as they have groups
         tool_sources = self._get_tool_sources(tool_keywords)
         for key in SOURCE_KEYS:
-           self.project['export'][key] = merge_recursive(self.project['export'][key], tool_sources[key])
+            self.project['export'][key] = merge_recursive(self.project['export'][key], tool_sources[key])
+            # sort all sources within its own group and own category (=k)
+            # the tool needs to do sort files as tools require further processing based on 
+            # categories (we can't mix now cpp and c files for instance)
+            for k, v in self.project['export'][key].items():
+                self.project['export'][key][k] = sorted(v, key=lambda x: os.path.basename(x))
 
         self.project['export']['include_files'] = merge_recursive(self.project['export']['include_files'], self._get_tool_includes(tool_keywords))
 

--- a/project_generator/tools/coide.py
+++ b/project_generator/tools/coide.py
@@ -153,6 +153,7 @@ class Coide(Tool, Exporter, Builder):
                 if group:
                     file['@name'] = group + '/' + file['@name']
                 coproj_dic['Project']['Files']['File'].append(file)
+        coproj_dic['Project']['Files']['File'] = sorted(coproj_dic['Project']['Files']['File'], key=lambda x: basename(x['@path'].lower()))
 
     def _coproj_set_macros(self, coproj_dic, project_dic):
         coproj_dic['Project']['Target']['BuildOption']['Compile']['DefinedSymbols']['Define'] = []

--- a/project_generator/tools/eclipse.py
+++ b/project_generator/tools/eclipse.py
@@ -68,6 +68,7 @@ class EclipseGnuARM(Tool, Exporter, Builder):
                 new_file = {"path": join('PARENT-%s-PROJECT_LOC' % new_data['output_dir']['rel_path'], normpath(source)), "name": basename(
                     source), "type": self.file_types[extension.lower()]}
                 new_data['groups'][group].append(new_file)
+        new_data['groups'][group] = sorted(new_data['groups'][group], key=lambda x: x['name'].lower())
 
 #TODO: eliminate this duplicate in many tools. Same applies to _iterate
     def _get_groups(self, data):

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -174,6 +174,7 @@ class IAREmbeddedWorkbenchProject:
             ewp_dic['project']['group'].append({'name': group_name, 'file': []})
             for file in files:
                 ewp_dic['project']['group'][i]['file'].append({'name': file})
+            ewp_dic['project']['group'][i]['file'] = sorted(ewp_dic['project']['group'][i]['file'], key=lambda x: os.path.basename(x['name'].lower()))
             i += 1
 
     def _clean_xmldict_option(self, dictionary):

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -243,6 +243,8 @@ class Uvision(Tool, Builder, Exporter):
             uvproj_dic['Project']['Targets']['Target']['Groups']['Group'].append(group)
             for file in files:
                 uvproj_dic['Project']['Targets']['Target']['Groups']['Group'][i]['Files']['File'].append(file)
+            files = uvproj_dic['Project']['Targets']['Target']['Groups']['Group'][i]['Files']['File']
+            uvproj_dic['Project']['Targets']['Target']['Groups']['Group'][i]['Files']['File'] = sorted(files, key=lambda x: x['FileName'].lower())
             i += 1
 
     def _generate_uvmpw_file(self):


### PR DESCRIPTION
A tool requires to do further sorting. As there are source groups and they can have own groups.
Therefore if tool has a virtual dir, it merges all files for specific group and sort them.


I fixed iar and uvision. I'll continue with other tools within this PR