### PR TITLE
gcc makefile - fix mkdir for windows

### DIFF
--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -132,7 +132,7 @@ all: create_outputdir $(OBJ_FOLDER)$(TARGET).$(TARGET_EXT) print_info
 
 create_outputdir:
 ifeq ($(OS),Windows_NT)
-	mkdir $(OUT_DIR)
+	-mkdir $(OUT_DIR)
 else
 	$(shell mkdir $(OBJ_FOLDER) 2>/dev/null)
 endif


### PR DESCRIPTION
```
//before
mkdir build
A subdirectory or file build already exists.
make: *** [create_outputdir] Error 1

//after
mkdir build
A subdirectory or file build already exists.
build continues
```