### PR TITLE
IAR - .ewd file templates

### DIFF
--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -126,7 +126,7 @@ class ProjectTemplate:
             'output_type': output_type, # output type, default - exe
             'sources': [],              # source files/folders
             'target': '',               # target
-            'template' : '',            # tool template
+            'template' : [],            # tool template
             'tools_supported': [],      # Tools which are supported,
     """
 
@@ -148,7 +148,7 @@ class ProjectTemplate:
 
         data_template = {
             'misc': {},     # misc settings related to tools
-            'template': '', # template project file
+            'template': [], # template project file
         }
         return data_template
 

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -18,6 +18,7 @@ import xmltodict
 import subprocess
 import time
 import copy
+import re
 
 import os
 from os import getcwd
@@ -407,13 +408,14 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
             # process each template file
             for template in expanded_dic['template']:
                 template = join(getcwd(), template)
-                if os.path.splitext(template)[1] == '.ewp':
+                # we support .ewp or .ewp.tmpl templates
+                if os.path.splitext(template)[1] == '.ewp' or re.match('.*\.ewp.tmpl$', template):
                     try:
                         ewp_dic = xmltodict.parse(open(template), dict_constructor=dict)
                     except IOError:
                         logger.info("Template file %s not found" % template)
                         ewp_dic = self.definitions.ewp_file
-                elif os.path.splitext(template)[1] == '.ewd':
+                elif os.path.splitext(template)[1] == '.ewd' or re.match('.*\.ewd.tmpl$', template):
                     try:
                         ewd_dic = xmltodict.parse(open(template), dict_constructor=dict)
                     except IOError:
@@ -426,13 +428,13 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
             # template overrides what is set in the yaml files
             for template in self.env_settings.templates['iar']:
                 template = join(getcwd(), template)
-                if os.path.splitext(template)[1] == '.ewp':
+                if os.path.splitext(template)[1] == '.ewp' or re.match('.*\.ewp.tmpl$', template):
                     try:
                         ewp_dic = xmltodict.parse(open(template), dict_constructor=dict)
                     except IOError:
                         logger.info("Template file %s not found" % template)
                         ewp_dic = self.definitions.ewp_file
-                elif os.path.splitext(template)[1] == '.ewd':
+                elif os.path.splitext(template)[1] == '.ewd' or re.match('.*\.ewd.tmpl$', template):
                     # get ewd template
                     try:
                         ewd_dic = xmltodict.parse(open(template), dict_constructor=dict)

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -391,6 +391,11 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
             if option['name'] == find_key:
                 return settings.index(option)
 
+    def _get_default_templates(self):
+        ewp_dic = self.definitions.ewp_file
+        ewd_dic = self.definitions.ewd_file
+        return ewp_dic, ewd_dic
+
     def _export_single_project(self):
         """ A single project export """
         expanded_dic = self.workspace.copy()
@@ -399,27 +404,46 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
 
         # generic tool template specified or project
         if expanded_dic['template']:
-            # TODO 0xc0170: template list !
-            project_file = join(getcwd(), expanded_dic['template'][0])
-            try:
-                ewp_dic = xmltodict.parse(open(project_file), dict_constructor=dict)
-            except IOError:
-                logger.info("Template file %s not found" % project_file)
-                ewp_dic = self.definitions.ewp_file
+            # process each template file
+            for template in expanded_dic['template']:
+                template = join(getcwd(), template)
+                if os.path.splitext(template)[1] == '.ewp':
+                    try:
+                        ewp_dic = xmltodict.parse(open(template), dict_constructor=dict)
+                    except IOError:
+                        logger.info("Template file %s not found" % template)
+                        ewp_dic = self.definitions.ewp_file
+                elif os.path.splitext(template)[1] == '.ewd':
+                    try:
+                        ewd_dic = xmltodict.parse(open(template), dict_constructor=dict)
+                    except IOError:
+                        logger.info("Template file %s not found" % template)
+                        ewd_dic = self.definitions.ewd_file
+                else:
+                    logger.info("Template file %s contains unknown template extension (.ewp, .ewd are valid)" % template)
+                    ewp_dic, ewd_dic = self._get_default_templates()
         elif 'iar' in self.env_settings.templates.keys():
             # template overrides what is set in the yaml files
-            # TODO 0xc0170: extension check/expansion
-            project_file = join(getcwd(), self.env_settings.templates['iar'][0])
-            try:
-                ewp_dic = xmltodict.parse(open(project_file), dict_constructor=dict)
-            except IOError:
-                logger.info("Template file %s not found" % project_file)
-                ewp_dic = self.definitions.ewp_file
+            for template in self.env_settings.templates['iar']:
+                template = join(getcwd(), template)
+                if os.path.splitext(template)[1] == '.ewp':
+                    try:
+                        ewp_dic = xmltodict.parse(open(template), dict_constructor=dict)
+                    except IOError:
+                        logger.info("Template file %s not found" % template)
+                        ewp_dic = self.definitions.ewp_file
+                elif os.path.splitext(template)[1] == '.ewd':
+                    # get ewd template
+                    try:
+                        ewd_dic = xmltodict.parse(open(template), dict_constructor=dict)
+                    except IOError:
+                        logger.info("Template file %s not found" % template)
+                        ewd_dic = self.definitions.ewd_file
+                else:
+                    logger.info("Template file %s contains unknown template extension (.ewp, .ewd are valid)" % template)
+                    ewp_dic, ewd_dic = self._get_default_templates()
         else:
-            ewp_dic = self.definitions.ewp_file
-
-        # TODO 0xc0170: add ewd file parsing and support
-        ewd_dic = self.definitions.ewd_file
+            ewp_dic, ewd_dic = self._get_default_templates()
 
         eww = None
         if self.workspace['singular']:

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -18,6 +18,7 @@ import shutil
 import logging
 import xmltodict
 import copy
+import re
 
 from os import getcwd
 from os.path import basename, join, normpath
@@ -329,7 +330,8 @@ class Uvision(Tool, Builder, Exporter):
         if expanded_dic['template']:
             for template in expanded_dic['template']:
                 template = join(getcwd(), template)
-                if os.path.splitext(template)[1] == '.uvproj' or os.path.splitext(template)[1] == '.uvprojx':
+                if os.path.splitext(template)[1] == '.uvproj' or os.path.splitext(template)[1] == '.uvprojx' or \
+                    re.match('.*\.uvproj.tmpl$', template) or re.match('.*\.uvprojx.tmpl$', template):
                     try:
                         uvproj_dic = xmltodict.parse(open(template))
                     except IOError:
@@ -342,7 +344,8 @@ class Uvision(Tool, Builder, Exporter):
             # template overrides what is set in the yaml files
             for template in self.env_settings.templates['uvision']:
                 template = join(getcwd(), template)
-                if os.path.splitext(template)[1] == '.uvproj' or os.path.splitext(template)[1] == '.uvprojx':
+                if os.path.splitext(template)[1] == '.uvproj' or os.path.splitext(template)[1] == '.uvprojx' or \
+                    re.match('.*\.uvproj.tmpl$', template) or re.match('.*\.uvprojx.tmpl$', template):
                     try:
                         uvproj_dic = xmltodict.parse(open(template))
                     except IOError:

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -327,23 +327,30 @@ class Uvision(Tool, Builder, Exporter):
 
         # generic tool template specified or project
         if expanded_dic['template']:
-            # TODO 0xc0170: template list !
-            project_file = join(getcwd(), expanded_dic['template'][0])
-            try:
-                uvproj_dic = xmltodict.parse(open(project_file))
-            except IOError:
-                logger.info("Template file %s not found" % project_file)
-                return None, None
+            for template in expanded_dic['template']:
+                template = join(getcwd(), template)
+                if os.path.splitext(template)[1] == '.uvproj' or os.path.splitext(template)[1] == '.uvprojx':
+                    try:
+                        uvproj_dic = xmltodict.parse(open(template))
+                    except IOError:
+                        logger.info("Template file %s not found" % template)
+                        return None, None
+                else:
+                    logger.info("Template file %s contains unknown template extension (.uvproj/x are valid). Using default one" % template)
+                    uvproj_dic = self.definitions.uvproj_file
         elif 'uvision' in self.env_settings.templates.keys():
             # template overrides what is set in the yaml files
-            # TODO 0xc0170: extensions for templates - support multiple files and get their extension
-            # and check if user defined them correctly
-            project_file = join(getcwd(), self.env_settings.templates['uvision'][0])
-            try:
-                uvproj_dic = xmltodict.parse(open(project_file))
-            except IOError:
-                logger.info("Template file %s not found. Using default template" % project_file)
-                uvproj_dic = self.definitions.uvproj_file
+            for template in self.env_settings.templates['uvision']:
+                template = join(getcwd(), template)
+                if os.path.splitext(template)[1] == '.uvproj' or os.path.splitext(template)[1] == '.uvprojx':
+                    try:
+                        uvproj_dic = xmltodict.parse(open(template))
+                    except IOError:
+                        logger.info("Template file %s not found. Using default template" % template)
+                        uvproj_dic = self.definitions.uvproj_file
+                else:
+                    logger.info("Template file %s contains unknown template extension (.uvproj/x are valid). Using default one" % template)
+                    uvproj_dic = self.definitions.uvproj_file
         else:
             uvproj_dic = self.definitions.uvproj_file
 


### PR DESCRIPTION
It should fix #364. Adding multimple templates to the picture. This relies on the
extension of the templates. Previously, only one template was supported, thus we did
not care about extension.

@RyoheiHagimoto  Can you please test ? Add to template list for progen, .ewd file. I have to add more sugar to accept .ewd.tmpl as there are in mbed. I quickly tested .ewp and .ewd template files (removed .tmpl extension).

```
ewd file - .ewd
ewp file - .ewp

change in iar in exporters in mbed, the template names to .ewd and .ewl , same for files there, should work
```