### PR TITLE
Tools - sort groups

### DIFF
--- a/project_generator/tools/coide.py
+++ b/project_generator/tools/coide.py
@@ -122,6 +122,9 @@ class Coide(Tool, Exporter, Builder):
                 group = k
             self._expand_data(data['include_files'], expanded_data, attribute, group)
 
+        # sort groups
+        expanded_data['groups'] = OrderedDict(sorted(expanded_data['groups'].items(), key=lambda t: t[0]))
+
     def _normalize_mcu_def(self, mcu_def):
         for k, v in mcu_def['Device'].items():
             mcu_def['Device'][k] = v[0]

--- a/project_generator/tools/eclipse.py
+++ b/project_generator/tools/eclipse.py
@@ -15,6 +15,7 @@
 import copy
 import logging
 
+from collections import OrderedDict
 # eclipse works with linux paths
 from posixpath import normpath, join, basename
 
@@ -102,6 +103,9 @@ class EclipseGnuARM(Tool, Exporter, Builder):
             else:
                 group = k
             self._expand_data(data['include_files'], expanded_data, attribute, group)
+
+        # sort groups
+        expanded_data['groups'] = OrderedDict(sorted(expanded_data['groups'].items(), key=lambda t: t[0]))
 
     def export_workspace(self):
         logger.debug("Current version of CoIDE does not support workspaces")

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -374,6 +374,9 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                 data['groups'][k] = []
             data['groups'][k].extend([join('$PROJ_DIR$', file) for file in v])
 
+        # sort groups
+        data['groups'] = OrderedDict(sorted(data['groups'].items(), key=lambda t: t[0]))
+
     def _get_option(self, settings, find_key):
         """ Return index for provided key """
         # This is used as in IAR template, everything 

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -153,6 +153,8 @@ class Uvision(Tool, Builder, Exporter):
                 group = k
             self._expand_data(data['include_files'], expanded_data, attribute, group)
 
+        # sort groups
+        expanded_data['groups'] = OrderedDict(sorted(expanded_data['groups'].items(), key=lambda t: t[0]))
 
     def _get_groups(self, data):
         """ Get all groups defined. """


### PR DESCRIPTION
Files are sorted in the groups, and now also groups. Otherwise,
the workspace is a clutter without any order.

Tools do own magic with groups, thus this seems like copy-paste job. We should look at how tools process data (iterate pattern is present there, so we might do that in the generic way).