### PR TITLE
Restructure build directory, Allow additional targets from projcet.yaml

### DIFF
--- a/project_generator/commands/__init__.py
+++ b/project_generator/commands/__init__.py
@@ -11,3 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import argparse
+from os.path import exists
+
+def argparse_filestring_type(string):
+    if not exists(string):
+        raise argparse.ArgumentTypeError("%s is not a file." % string)
+    else:
+        return string
+
+def argparse_string_type(case_converter, prefer_hyphen=False):
+    if prefer_hyphen:
+        return lambda string: case_converter(string).replace("_","-")
+    else:
+        return lambda string: case_converter(string).replace("-","_")

--- a/project_generator/commands/build.py
+++ b/project_generator/commands/build.py
@@ -17,37 +17,35 @@ import logging
 from ..tools_supported import ToolsSupported
 from ..generate import Generator
 from ..settings import ProjectSettings
+from . import argparse_filestring_type, argparse_string_type
 
 help = 'Build a project'
 
 
 def run(args):
     # Export if we know how, otherwise return
-    if os.path.exists(args.file):
-        generator = Generator(args.file)
-        build_failed = False
-        export_failed = False
-        for project in generator.generate(args.project):
-            if project.generate(args.tool, args.copy) == -1:
-                export_failed = True
-            if project.build(args.tool) == -1:
-                build_failed = True
+    generator = Generator(args.file)
+    build_failed = False
+    export_failed = False
+    for project in generator.generate(args.project):
+        if project.generate(args.tool, args.copy) == -1:
+            export_failed = True
+        if project.build(args.tool) == -1:
+            build_failed = True
 
-        if build_failed or export_failed:
-            return -1
-        else:
-            return 0
-    else:
-        # not project known by progen
-        logging.warning("%s not found." % args.file)
+    if build_failed or export_failed:
         return -1
+    else:
+        return 0
 
 def setup(subparser):
     subparser.add_argument(
-        "-f", "--file", help="YAML projects file", default='projects.yaml')
+        "-f", "--file", help="YAML projects file", default='projects.yaml',
+        type=argparse_filestring_type)
     subparser.add_argument(
         "-p", "--project", help="Name of the project to build", default = '')
     subparser.add_argument(
-        "-t", "--tool", help="Build a project files for provided tool")
+        "-t", "--tool", help="Build a project files for provided tool",
+        type=argparse_string_type(str.lower, False), choices=list(ToolsSupported.TOOLS_DICT.keys()) + list(ToolsSupported.TOOLS_ALIAS.keys()))
     subparser.add_argument(
         "-c", "--copy", action="store_true", help="Copy all files to the exported directory")

--- a/project_generator/commands/clean.py
+++ b/project_generator/commands/clean.py
@@ -14,24 +14,22 @@
 import os
 import logging
 
+from ..tools_supported import ToolsSupported
 from ..generate import Generator
+from . import argparse_filestring_type, argparse_string_type
 
 help = 'Clean generated projects'
 
 
 def run(args):
-    if os.path.exists(args.file):
-        generator = Generator(args.file)
-        for project in generator.generate(args.project):
-            project.clean(args.tool)
-    else:
-        # not project known by progen
-        logging.warning("%s not found." % args.file)
-        return -1
+    generator = Generator(args.file)
+    for project in generator.generate(args.project):
+        project.clean(args.tool)
     return 0
 
 def setup(subparser):
-    subparser.add_argument("-f", "--file", help="YAML projects file", default='projects.yaml')
+    subparser.add_argument("-f", "--file", help="YAML projects file", default='projects.yaml', type=argparse_filestring_type)
     subparser.add_argument("-p", "--project", required = True, help="Specify which project to be removed")
     subparser.add_argument(
-        "-t", "--tool", help="Clean project files for this tool")
+        "-t", "--tool", help="Clean project files for this tool",
+        type=argparse_string_type(str.lower, False), choices=list(ToolsSupported.TOOLS_DICT.keys()) + list(ToolsSupported.TOOLS_ALIAS.keys()))

--- a/project_generator/commands/generate.py
+++ b/project_generator/commands/generate.py
@@ -14,39 +14,37 @@
 import os
 import logging
 
+from ..tools_supported import ToolsSupported
 from ..generate import Generator
+from . import argparse_filestring_type, argparse_string_type
 
 help = 'Generate a project record'
 
 def run(args):
-    if os.path.exists(args.file):
-        generator = Generator(args.file)
-        build_failed = False
-        export_failed = False
-        generated = True
-        for project in generator.generate(args.project):
-            generated = False
-            if project.generate(args.tool, copied=args.copy, copy=args.copy) == -1:
-                export_failed = True
-            if args.build:
-                if project.build(args.tool) == -1:
-                    build_failed = True
-        if build_failed or export_failed or generated:
-            return -1
-        else:
-            return 0
-    else:
-        # not project known by progen
-        logging.warning("%s not found." % args.file)
+    generator = Generator(args.file)
+    build_failed = False
+    export_failed = False
+    generated = True
+    for project in generator.generate(args.project):
+        generated = False
+        if project.generate(args.tool, copied=args.copy, copy=args.copy) == -1:
+            export_failed = True
+        if args.build:
+            if project.build(args.tool) == -1:
+                build_failed = True
+    if build_failed or export_failed or generated:
         return -1
+    else:
+        return 0
 
 def setup(subparser):
     subparser.add_argument(
-        "-f", "--file", help="YAML projects file", default='projects.yaml')
+        "-f", "--file", help="YAML projects file", default='projects.yaml', type=argparse_filestring_type)
     subparser.add_argument(
         "-p", "--project", help="Project to be generated", default = '')
     subparser.add_argument(
-        "-t", "--tool", help="Create project files for provided tool")
+        "-t", "--tool", help="Create project files for provided tool",
+        type=argparse_string_type(str.lower, False), choices=list(ToolsSupported.TOOLS_DICT.keys()) + list(ToolsSupported.TOOLS_ALIAS.keys()))
     subparser.add_argument(
         "-b", "--build", action="store_true", help="Build defined projects")
     subparser.add_argument(

--- a/project_generator/commands/list_projects.py
+++ b/project_generator/commands/list_projects.py
@@ -18,6 +18,7 @@ from project_generator_definitions.definitions import ProGenTargets
 from ..tools_supported import ToolsSupported
 from ..generate import Generator
 from ..settings import ProjectSettings
+from . import argparse_filestring_type
 
 help = 'List general progen data as projects, tools or targets'
 
@@ -49,4 +50,4 @@ def run(args):
 def setup(subparser):
     subparser.add_argument("section", choices = ['targets','tools','projects'],
                            help="What section you would like listed", default='projects')
-    subparser.add_argument("-f", "--file", help="YAML projects file")
+    subparser.add_argument("-f", "--file", help="YAML projects file", type=argparse_filestring_type)

--- a/project_generator/generate.py
+++ b/project_generator/generate.py
@@ -55,11 +55,13 @@ class Generator:
         else:
             if 'projects' in self.projects_dict:
                 found = True
-                for name, records in self.projects_dict['projects'].items():
+                for name, records in sorted(self.projects_dict['projects'].items(),
+                                            key=lambda x: x[0]):
                     yield Project(name, load_yaml_records(uniqify(flatten(records))), self.settings)
             if 'workspaces' in self.projects_dict:
                 found = True
-                for name, records in self.projects_dict['workspaces'].items():
+                for name, records in sorted(self.projects_dict['workspaces'].items(),
+                                            key=lambda x: x[0]):
                     workspace_settings = {}
                     if 'settings' in records:
                         workspace_settings = records['settings']

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -89,10 +89,12 @@ LD_OPTIONS += {% block LD_OPTIONS %}{% endblock %}
 
 ARFLAGS = cr
 
-ifeq ($(OS),Windows_NT)
-	RM = rmdir /s /q
+ifeq ($(shell echo $$OS),$$OS)
+    MAKEDIR = if not exist "$(1)" mkdir "$(1)"
+    RM = rmdir /S /Q "$(1)"
 else
-	RM = rm -rf
+    MAKEDIR = $(SHELL) -c "mkdir -p \"$(1)\""
+    RM = $(SHELL) -c "rm -rf \"$(1)\""
 endif
 
 C_SRCS := {% for file in source_files_c %} {{file}} {% endfor %}
@@ -107,23 +109,26 @@ S_OBJS += $(patsubst %.S,$(OBJ_FOLDER)%.o,$(filter %.S,$(S_SRCS)))
 
 O_OBJS := {% for file in source_files_obj %} {{file}} {% endfor %}
 
-$(OBJ_FOLDER)%.o : %.c | create_outputdir
+$(OBJ_FOLDER)%.o : %.c
 	@echo 'Building file: $(@F)'
 	@echo 'Invoking: MCU C Compiler'
+	@$(call MAKEDIR,$(dir $@))
 	$(CC) $(CFLAGS) $(COMMON_FLAGS) $< -o $@
 	@echo 'Finished building: $(@F)'
 	@echo ' '
 
-$(OBJ_FOLDER)%.o : %.cpp | create_outputdir
+$(OBJ_FOLDER)%.o : %.cpp
 	@echo 'Building file: $(@F)'
 	@echo 'Invoking: MCU C++ Compiler'
+	@$(call MAKEDIR,$(dir $@))
 	$(CXX) $(CXXFLAGS) $(COMMON_FLAGS) $< -o $@
 	@echo 'Finished building: $(@F)'
 	@echo ' '
 
-$(OBJ_FOLDER)%.o : %.s | create_outputdir
+$(OBJ_FOLDER)%.o : %.s
 	@echo 'Building file: $(@F)'
 	@echo 'Invoking: MCU Assembler'
+	@$(call MAKEDIR,$(dir $@))
 	$(AS) $(ASFLAGS) $(COMMON_FLAGS) $< -o $@
 	@echo 'Finished building: $(@F)'
 	@echo ' '
@@ -133,22 +138,12 @@ PRE_BUILD_SCRIPT := $(shell{% for command in pre_build_script %} ../../../{{comm
 all: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) print_info
 	{% for command in post_build_script %} ../../../{{command}} && {% endfor %} true
 
-create_outputdir:
-ifeq ($(OS),Windows_NT)
-	-@mkdir $(OUT_FOLDER)
-{% for dir in source_paths %}
-	-@mkdir $(OBJ_FOLDER){{dir}}{% endfor %}
-else
-	@mkdir -p $(OBJ_FOLDER) 2>/dev/null
-{% for dir in source_paths %}
-	@mkdir -p $(OBJ_FOLDER){{dir}} 2>/dev/null{% endfor %}
-endif
-
 {% if output_type == 'exe' %}
 # Tool invocations
 $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: MCU Linker'
+	@$(call MAKEDIR,$(dir $@))
 	$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS) 
 	@echo 'Finished building target: $@'
 	@echo ' '
@@ -165,6 +160,7 @@ print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 {% else %}
 $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Building library: $@'
+	@$(call MAKEDIR,$(dir $@))
 	$(AR) rcs $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) $(CPP_OBJS) $(C_OBJS) $(S_OBJS)
 	@echo 'Finished building library: $@'
 	@echo ' '
@@ -181,7 +177,7 @@ print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 # Other Targets
 clean:
 	@echo 'Removing entire out directory'
-	$(RM) $(TARGET)$(TARGET_EXT) $(TARGET).bin $(TARGET).map $(OBJ_FOLDER)*.* $(OBJ_FOLDER)
+	$(call RM $(TARGET)$(TARGET_EXT) $(TARGET).bin $(TARGET).map $(OBJ_FOLDER)*.* $(OBJ_FOLDER))
 	@echo ' '
 
 .PHONY: clean print_info

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -150,7 +150,7 @@ $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS
 	@echo 'Finished building target: $@'
 	@echo ' '
 
-print_info:
+print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	@echo 'Printing size'
 	$(SIZE) --totals $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	$(OBJCOPY) {% block TOHEX %}{% endblock %} $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) {% block objcopy_output %}{% endblock %} $(OBJ_FOLDER)$(TARGET).hex
@@ -166,7 +166,7 @@ $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Finished building library: $@'
 	@echo ' '
 
-print_info:
+print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	@echo 'Printing size'
 	$(SIZE) --totals $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	@echo ' '

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -15,6 +15,8 @@
 
 # This project was exported via the project generator.  More information https://github.com/project-generator/project_generator
 
+.SUFFIXES: .
+
 CPU = {{core}}
 
 # toolchain specific
@@ -41,6 +43,7 @@ TARGET_EXT = .a
 {% endif %}
 
 LD_SCRIPT = {{linker_file}}
+VPATH += {{output_dir.rel_path}}
 
 CC_SYMBOLS = {% for symbol in macros %} -D{{symbol}} {% endfor %}
 ASM_SYMBOLS = {% block ASM_SYMBOLS %}{% endblock %}
@@ -76,15 +79,13 @@ C_FLAGS  = {% for option in c_flags %} {{option}} {% endfor %}
 CXX_FLAGS  = {% for option in cxx_flags %} {{option}} {% endfor %}
 ASM_FLAGS  = {% for option in asm_flags %} {{option}} {% endfor %}
 
-CFLAGS = $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS)
+CFLAGS += $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS)
 CXXFLAGS = $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS)
 ASFLAGS = $(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS)
 
 # Linker options
 LD_OPTIONS += {% for option in ld_flags %} {{option}} {% endfor %}
 LD_OPTIONS += {% block LD_OPTIONS %}{% endblock %}
-
-OBJCPFLAGS = -O ihex
 
 ARFLAGS = cr
 
@@ -95,34 +96,32 @@ else
 endif
 
 C_SRCS := {% for file in source_files_c %} {{file}} {% endfor %}
-C_OBJS := $(patsubst %.c,$(OBJ_FOLDER)%.o,$(notdir $(C_SRCS)))
+C_OBJS := $(patsubst %.c,$(OBJ_FOLDER)%.o,$(C_SRCS))
 
 CPP_SRCS := {% for file in source_files_cpp %} {{file}} {% endfor %}
-CPP_OBJS := $(patsubst %.cpp,$(OBJ_FOLDER)%.o,$(notdir $(CPP_SRCS)))
+CPP_OBJS := $(patsubst %.cpp,$(OBJ_FOLDER)%.o,$(CPP_SRCS))
 
 S_SRCS := {% for file in source_files_s %} {{file}} {% endfor %}
-S_OBJS = $(patsubst %.s,$(OBJ_FOLDER)%.o,$(filter %.s,$(notdir $(S_SRCS))))
-S_OBJS += $(patsubst %.S,$(OBJ_FOLDER)%.o,$(filter %.S,$(notdir $(S_SRCS))))
+S_OBJS = $(patsubst %.s,$(OBJ_FOLDER)%.o,$(filter %.s,$(S_SRCS)))
+S_OBJS += $(patsubst %.S,$(OBJ_FOLDER)%.o,$(filter %.S,$(S_SRCS)))
 
 O_OBJS := {% for file in source_files_obj %} {{file}} {% endfor %}
 
-VPATH := $(SRC_DIRS)
-
-$(OBJ_FOLDER)%.o : %.c
+$(OBJ_FOLDER)%.o : %.c | create_outputdir
 	@echo 'Building file: $(@F)'
 	@echo 'Invoking: MCU C Compiler'
 	$(CC) $(CFLAGS) $(COMMON_FLAGS) $< -o $@
 	@echo 'Finished building: $(@F)'
 	@echo ' '
 
-$(OBJ_FOLDER)%.o : %.cpp
+$(OBJ_FOLDER)%.o : %.cpp | create_outputdir
 	@echo 'Building file: $(@F)'
 	@echo 'Invoking: MCU C++ Compiler'
 	$(CXX) $(CXXFLAGS) $(COMMON_FLAGS) $< -o $@
 	@echo 'Finished building: $(@F)'
 	@echo ' '
 
-$(OBJ_FOLDER)%.o : %.s
+$(OBJ_FOLDER)%.o : %.s | create_outputdir
 	@echo 'Building file: $(@F)'
 	@echo 'Invoking: MCU Assembler'
 	$(AS) $(ASFLAGS) $(COMMON_FLAGS) $< -o $@
@@ -131,14 +130,18 @@ $(OBJ_FOLDER)%.o : %.s
 
 PRE_BUILD_SCRIPT := $(shell{% for command in pre_build_script %} ../../../{{command}} && {% endfor %} true)
 
-all: create_outputdir $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) print_info
+all: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) print_info
 	{% for command in post_build_script %} ../../../{{command}} && {% endfor %} true
 
 create_outputdir:
 ifeq ($(OS),Windows_NT)
-	-mkdir $(OUT_DIR)
+	-@mkdir $(OUT_FOLDER)
+{% for dir in source_paths %}
+	-@mkdir $(OBJ_FOLDER){{dir}}{% endfor %}
 else
-	$(shell mkdir $(OBJ_FOLDER) 2>/dev/null)
+	@mkdir -p $(OBJ_FOLDER) 2>/dev/null
+{% for dir in source_paths %}
+	@mkdir -p $(OBJ_FOLDER){{dir}} 2>/dev/null{% endfor %}
 endif
 
 {% if output_type == 'exe' %}
@@ -171,6 +174,9 @@ print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	$(SIZE) --totals $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	@echo ' '
 {% endif %}
+
+{% for rule in additional_targets %}{{rule}}
+{% endfor %}
 
 # Other Targets
 clean:

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -1,4 +1,4 @@
-{% extends "makefile.tmpl" %}
+    {% extends "makefile.tmpl" %}
 
 {% block CC %}armcc{% endblock %}
 {% block CXX %}armcc{% endblock %}
@@ -12,5 +12,5 @@
 {% block objcopy_output %}--output{% endblock %}
 
 {% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
-{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
+{% block LD_OPTIONS %}--strict --scatter $(filter %.sct, $^) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
 {% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -13,4 +13,4 @@
 
 {% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
-{% block ASM_SYMBOLS %}{% for symbol in macros %} --pd "{{ morph_define(symbol) }}" {% endfor %}{% endblock %}
+{% block ASM_SYMBOLS %}{% for symbol in macros %} --d "{{ morph_define(symbol) }}" {% endfor %}{% endblock %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -13,4 +13,4 @@
 
 {% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
-{% block ASM_SYMBOLS %}{% for symbol in macros %} --d "{{ morph_define(symbol) }}" {% endfor %}{% endblock %}
+{% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -10,5 +10,5 @@
 {% block TOBIN %}-O binary{% endblock %}
 
 {% block COMMON_FLAGS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -MMD -MP $(CC_SYMBOLS) {% endblock %}
-{% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT){% endblock %}
+{% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(filter-out %.o, $^){% endblock %}
 {% block ASM_SYMBOLS %}$(CC_SYMBOLS){% endblock %}

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -571,7 +571,9 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
             logger.error("Project: %s build failed. Please check IARBUILD path in the user_settings.py file." % self.workspace['files']['ewp'])
             return -1
         else:
-            logger.debug(output)
+            build_log_path = os.path.join(os.path.dirname(proj_path),'build_log.txt')
+            with open(build_log_path, 'w') as f:
+                f.write(output)
             num_errors = self._parse_subprocess_output(output)
             if num_errors == 0:
                 logger.info("Project: %s build completed." % self.workspace['files']['ewp'])

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -395,7 +395,7 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                     except IOError:
                         logger.info("Template file %s not found" % template)
                         ewd_dic = self.definitions.ewd_file
-                if not template_ewp or not template_ewd:
+                if not template_ewp and not template_ewd:
                     logger.info("Template file %s contains unknown template extension (.ewp, .ewd are valid)" % template)
                     if not template_ewp and template_ewd:
                         ewp_dic, _ = self._get_default_templates() 
@@ -427,7 +427,7 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                 else:
                     # load default ewd if not found in the templates
                     ewd_dic = self.definitions.ewd_file
-                if not template_ewp or not template_ewd:
+                if not template_ewp and not template_ewd:
                     logger.info("Template file %s contains unknown template extension (.ewp, .ewd are valid)" % template)
                     ewp_dic, ewd_dic = self._get_default_templates()
         else:

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -395,14 +395,13 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                     except IOError:
                         logger.info("Template file %s not found" % template)
                         ewd_dic = self.definitions.ewd_file
-                if not template_ewp and not template_ewd:
-                    logger.info("Template file %s contains unknown template extension (.ewp, .ewd are valid)" % template)
-                    if not template_ewp and template_ewd:
-                        ewp_dic, _ = self._get_default_templates() 
-                    elif not template_ewd and template_ewp:
-                        _, ewd_dic = self._get_default_templates()
-                    else:
-                        ewp_dic, ewd_dic = self._get_default_templates()
+                # handle non valid template files or not specified
+                if not template_ewp and template_ewd:
+                    ewp_dic, _ = self._get_default_templates() 
+                elif not template_ewd and template_ewp:
+                    _, ewd_dic = self._get_default_templates()
+                else:
+                    ewp_dic, ewd_dic = self._get_default_templates()
         elif 'iar' in self.env_settings.templates.keys():
             template_ewp = False
             template_ewd = False
@@ -423,12 +422,13 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                         template_ewd = True
                     except IOError:
                         logger.info("Template file %s not found" % template)
-                        ewd_dic = self.definitions.ewd_file
+                        ewd_dic = self.definitions.ewd_filele
+                # handle non valid template files or not specified
+                if not template_ewp and template_ewd:
+                    ewp_dic, _ = self._get_default_templates() 
+                elif not template_ewd and template_ewp:
+                    _, ewd_dic = self._get_default_templates()
                 else:
-                    # load default ewd if not found in the templates
-                    ewd_dic = self.definitions.ewd_file
-                if not template_ewp and not template_ewd:
-                    logger.info("Template file %s contains unknown template extension (.ewp, .ewd are valid)" % template)
                     ewp_dic, ewd_dic = self._get_default_templates()
         else:
             ewp_dic, ewd_dic = self._get_default_templates()

--- a/project_generator/tools/makearmcc.py
+++ b/project_generator/tools/makearmcc.py
@@ -38,12 +38,3 @@ class MakefileArmcc(MakefileTool):
         self.process_data_for_makefile(self.workspace)
         generated_projects['path'], generated_projects['files']['makefile'] = self.gen_file_jinja('makefile_armcc.tmpl', self.workspace, 'Makefile', self.workspace['output_dir']['path'])
         return generated_projects
-
-    def process_data_for_makefile(self, project_data):
-        def morph_define (define) :
-            if '=' in define :
-                return define.replace("=", " SETA ")
-            else :
-                return define + " SETA 1 "
-        project_data['morph_define'] = morph_define
-        MakefileTool.process_data_for_makefile(self, project_data)

--- a/project_generator/tools/makefile.py
+++ b/project_generator/tools/makefile.py
@@ -23,7 +23,7 @@ from os.path import join, normpath,dirname
 from project_generator_definitions.definitions import ProGenDef
 
 from .tool import Tool, Exporter
-from ..util import SOURCE_KEYS
+from ..util import SOURCE_KEYS, strip_start
 
 
 class MakefileTool(Tool, Exporter):
@@ -111,6 +111,12 @@ class MakefileTool(Tool, Exporter):
         # change cortex-m0+ to cortex-m0plus
         if project_data['core'] == 'cortex-m0+':
             project_data['core'] = 'cortex-m0plus'
+
+        for key in ['source_files_c','source_files_cpp','source_files_s', 'source_paths']:
+            project_data[key] = [strip_start(f,project_data['output_dir']['rel_path'])
+                                 for f in project_data[key]]
+        project_data['linker_file'] = strip_start(project_data['linker_file'],
+                                                  project_data['output_dir']['rel_path'])
 
     def build_project(self):
         # cwd: relpath(join(project_path, ("gcc_arm" + project)))

--- a/project_generator/tools/tool.py
+++ b/project_generator/tools/tool.py
@@ -14,10 +14,13 @@
 
 import os
 import logging
+from collections import OrderedDict
 
-from os.path import join, dirname, abspath
+from os.path import join, dirname, abspath, normpath
 from jinja2 import Template, FileSystemLoader
 from jinja2.environment import Environment
+
+from ..util import SOURCE_KEYS
 
 logger = logging.getLogger('progen.tools')
 
@@ -103,3 +106,52 @@ class Exporter(object):
     @staticmethod
     def is_supported_by_default(target):
         return False
+
+    def _expand_data(self, old_data, new_data, group):
+        """ data expansion - uvision needs filename and path separately. """
+        for file in sum(old_data.values(), []):
+            if file:
+                extension = file.split(".")[-1].lower()
+                if extension in self.file_types.keys():
+                    new_data['groups'][group].append(self._expand_one_file(normpath(file),
+                                                                           new_data, extension))
+                else:
+                    logger.debug("Filetype for file %s not recognized" % file)
+        if hasattr(self, '_expand_sort_key'):
+            new_data['groups'][group] = sorted(new_data['groups'][group],
+                                               key=self._expand_sort_key)
+
+    def _get_groups(self, data):
+        """ Get all groups defined """
+        groups = []
+        for attribute in SOURCE_KEYS:
+            for k, v in data[attribute].items():
+                if k == None:
+                    k = 'Sources'
+                if k not in groups:
+                    groups.append(k)
+            for k, v in data['include_files'].items():
+                if k == None:
+                    k = 'Includes'
+                if k not in groups:
+                    groups.append(k)
+        return groups
+
+    def _iterate(self, data, expanded_data):
+        """ _Iterate through all data, store the result expansion in extended dictionary """
+        for attribute in SOURCE_KEYS:
+            for k, v in data[attribute].items():
+                if k == None:
+                    group = 'Sources'
+                else:
+                    group = k
+                self._expand_data(data[attribute], expanded_data, group)
+        for k, v in data['include_files'].items():
+            if k == None:
+                group = 'Includes'
+            else:
+                group = k
+            self._expand_data(data['include_files'], expanded_data, group)
+
+        # sort groups
+        expanded_data['groups'] = OrderedDict(sorted(expanded_data['groups'].items(), key=lambda t: t[0]))

--- a/project_generator/tools/tool.py
+++ b/project_generator/tools/tool.py
@@ -130,11 +130,11 @@ class Exporter(object):
                     k = 'Sources'
                 if k not in groups:
                     groups.append(k)
-            for k, v in data['include_files'].items():
-                if k == None:
-                    k = 'Includes'
-                if k not in groups:
-                    groups.append(k)
+        for k, v in data['include_files'].items():
+            if k == None:
+                k = 'Includes'
+            if k not in groups:
+                groups.append(k)
         return groups
 
     def _iterate(self, data, expanded_data):
@@ -152,7 +152,7 @@ class Exporter(object):
                 group = 'Includes'
             else:
                 group = k
-            self._expand_data(data['include_files'], expanded_data, group)
+            self._expand_data(data['include_files'][group], expanded_data, group)
 
         # sort groups
         expanded_data['groups'] = OrderedDict(sorted(expanded_data['groups'].items(), key=lambda t: t[0]))

--- a/project_generator/tools/tool.py
+++ b/project_generator/tools/tool.py
@@ -109,7 +109,7 @@ class Exporter(object):
 
     def _expand_data(self, old_data, new_data, group):
         """ data expansion - uvision needs filename and path separately. """
-        for file in sum(old_data.values(), []):
+        for file in old_data:
             if file:
                 extension = file.split(".")[-1].lower()
                 if extension in self.file_types.keys():
@@ -145,7 +145,8 @@ class Exporter(object):
                     group = 'Sources'
                 else:
                     group = k
-                self._expand_data(data[attribute], expanded_data, group)
+                if group in data[attribute].keys():
+                    self._expand_data(data[attribute][group], expanded_data, group)
         for k, v in data['include_files'].items():
             if k == None:
                 group = 'Includes'

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -37,48 +37,127 @@ class uVisionDefinitions():
 
     uvmpw_file = OrderedDict([(u'ProjectWorkspace', OrderedDict([(u'@xmlns:xsi', u'http://www.w3.org/2001/XMLSchema-instance'), (u'@xsi:noNamespaceSchemaLocation', u'project_mpw.xsd'), (u'SchemaVersion', u'1.0'), (u'Header', u'### uVision Project, (C) Keil Software'), (u'WorkspaceName', u'WorkSpace'), (u'project', OrderedDict([(u'PathAndName', None)]))]))])
 
+    uvoptx_file = OrderedDict([(u'ProjectOpt', OrderedDict(  [(u'@xmlns:xsi', u'http://www.w3.org/2001/XMLSchema-instance'), (u'@xsi:noNamespaceSchemaLocation', u'project_optx.xsd'), (u'SchemaVersion', u'1.0'), (u'Target', OrderedDict( [(u'TargetName', u''), (u'ToolsetNumber', u'0x4'), (u'ToolsetName', u'ARM-ADS'), (u'TargetOption', OrderedDict( [(u'DebugOpt', OrderedDict([(u'uSim', u'0'), (u'uTrg', u'1'), (u'nTsel', u''), (u'pMon', u'')])), (u'TargetDriverDllRegistry', OrderedDict( [(u'SetRegEntry', OrderedDict( [(u'Number', u'0'), (u'Key', u''), (u'Name', u'') ])) ])) ])) ])) ]))])
+
     debuggers = {
-        'cmsis-dap': {
-            'TargetDlls': {
-                'Driver': 'BIN\\CMSIS_AGDI.dll',
+        'ulink2-me': {
+            'uvproj': {
+                'TargetDlls': {
+                    'Driver': 'BIN\\UL2CM3.dll',
+                },
+                'Utilities': {
+                    'Flash2': 'BIN\\UL2CM3.DLL',
+                },
             },
-            'Utilities': {
-                'Flash2': 'BIN\\CMSIS_AGDI.dll',
+            'uvoptx' : {
+                'DebugOpt' : {
+                    'nTsel' : '1',
+                    'pMon': 'BIN\\UL2CM3.DLL',
+                },
+                'SetRegEntry' : {
+                    'Key' : 'UL2CM3',
+                },
+            },
+        },
+        'cmsis-dap': {
+            'uvproj': {
+                'TargetDlls': {
+                    'Driver': 'BIN\\CMSIS_AGDI.dll',
+                },
+                'Utilities': {
+                    'Flash2': 'BIN\\CMSIS_AGDI.dll',
+                },
+            },
+            'uvoptx' : {
+                'DebugOpt' : {
+                    'nTsel' : '12',
+                    'pMon': 'BIN\\CMSIS_AGDI.dll',
+                },
+                'SetRegEntry' : {
+                    'Key' : 'CMSIS_AGDI',
+                },
             },
         },
         'j-link': {
-            'TargetDlls': {
-                'Driver': 'Segger\\JL2CM3.dll',
+            'uvproj': {
+                'TargetDlls': {
+                    'Driver': 'Segger\\JL2CM3.dll',
+                },
+                'Utilities': {
+                    'Flash2': 'Segger\\JL2CM3.dll',
+                },
             },
-            'Utilities': {
-                'Flash2': 'Segger\\JL2CM3.dll',
+            'uvoptx' : {
+                'DebugOpt' : {
+                    'nTsel' : '6',
+                    'pMon': 'Segger\\JL2CM3.dll',
+                },
+                'SetRegEntry' : {
+                    'Key' : 'JL2CM3',
+                },
             },
         },
         'ulink-pro': {
-            'TargetDlls': {
-                'Driver': 'BIN\\ULP2CM3.dll',
+            'uvproj': {
+                'TargetDlls': {
+                    'Driver': 'BIN\\ULP2CM3.dll',
+                },
+                'Utilities': {
+                    'Flash2': 'BIN\\ULP2CM3.dll',
+                },
             },
-            'Utilities': {
-                'Flash2': 'BIN\\ULP2CM3.dll',
+            'uvoptx' : {
+                'DebugOpt' : {
+                    'nTsel' : '7',
+                    'pMon': 'BIN\\ULP2CM3.DLL',
+                },
+                'SetRegEntry' : {
+                    'Key' : 'ULP2CM3',
+                },
             },
         },
         'st-link': {
-            'TargetDlls': {
-                'Driver': 'STLink\\ST-LINKIII-KEIL_SWO.dll',
+            'uvproj': {
+                'TargetDlls': {
+                    'Driver': 'STLink\\ST-LINKIII-KEIL_SWO.dll',
+                },
+                'Utilities': {
+                    'Flash2': 'STLink\\ST-LINKIII-KEIL_SWO.dll',
+                },
             },
-            'Utilities': {
-                'Flash2': 'STLink\\ST-LINKIII-KEIL_SWO.dll',
+            'uvoptx' : {
+                'DebugOpt' : {
+                    'nTsel' : '11',
+                    'pMon': 'STLink\\ST-LINKIII-KEIL_SWO.dll',
+                },
+                'SetRegEntry' : {
+                    'Key' : 'ST-LINKIII-KEIL_SWO',
+                },
             },
         },
         'nu-link': {
-            'TargetDlls': {
-                'Driver': 'BIN\\Nu_Link.dll',
+            'uvproj': {
+                'TargetDlls': {
+                    'Driver': 'BIN\\Nu_Link.dll',
+                },
+                'Utilities': {
+                    'Flash2': 'BIN\\Nu_Link.dll',
+                },
             },
-            'Utilities': {
-                'Flash2': 'BIN\\Nu_Link.dll',
+            'uvoptx' : {
+                'DebugOpt' : {
+                    'nTsel' : '9',
+                    'pMon': 'NULink\\Nu_Link.dll',
+                },
+                'SetRegEntry' : {
+                    'Key' : 'Nu_Link',
+                },
             },
         },
     }
+
+    # use cmsis-dap debugger as default
+    debuggers_default = 'cmsis-dap'
 
 
 class Uvision(Tool, Builder, Exporter):
@@ -257,8 +336,8 @@ class Uvision(Tool, Builder, Exporter):
         # later progen can overwrite this if debugger is set in project data
         try:
             debugger_name = pro_def.get_debugger(expanded_dic['target'])['name']
-            uvproj_dic['Project']['Targets']['Target']['TargetOption']['DebugOption']['TargetDlls']['Driver'] = self.definitions.debuggers[debugger_name]['TargetDlls']['Driver']
-            uvproj_dic['Project']['Targets']['Target']['TargetOption']['Utilities']['Flash2'] = self.definitions.debuggers[debugger_name]['Utilities']['Flash2']
+            uvproj_dic['Project']['Targets']['Target']['TargetOption']['DebugOption']['TargetDlls']['Driver'] = self.definitions.debuggers[debugger_name]['uvproj']['TargetDlls']['Driver']
+            uvproj_dic['Project']['Targets']['Target']['TargetOption']['Utilities']['Flash2'] = self.definitions.debuggers[debugger_name]['uvproj']['Utilities']['Flash2']
         except (TypeError, KeyError) as err:
             pass
         # Support new device packs
@@ -267,6 +346,36 @@ class Uvision(Tool, Builder, Exporter):
                 # using software packs require v5
                 logger.info("The target might not be supported in %s, requires uvision5" % tool_name)
             uvproj_dic['Project']['Targets']['Target']['TargetOption']['TargetCommonOption']['PackID'] = mcu_def_dic['TargetOption']['PackID'][0]
+
+    def _uvoptx_set_debugger(self, expanded_dic, uvoptx_dic, tool_name):
+        pro_def = ProGenDef(tool_name)
+        if not pro_def.is_supported(expanded_dic['target'].lower()):
+            raise RuntimeError("Target %s is not supported. Please add them to https://github.com/project-generator/project_generator_definitions" % expanded_dic['target'].lower())
+        mcu_def_dic = pro_def.get_tool_definition(expanded_dic['target'].lower())
+        if not mcu_def_dic:
+             raise RuntimeError(
+                "Target definitions were not found for %s. Please add them to https://github.com/project-generator/project_generator_definitions" % expanded_dic['target'].lower())
+        logger.debug("Mcu definitions: %s" % mcu_def_dic)
+
+        # set the same target name FlashDriverDll config as in uvprojx file
+        try:
+            uvoptx_dic['ProjectOpt']['Target']['TargetName'] = expanded_dic['name']
+            uvoptx_dic['ProjectOpt']['Target']['TargetOption']['TargetDriverDllRegistry']['SetRegEntry']['Name'] = str(mcu_def_dic['TargetOption']['FlashDriverDll'][0]).encode('utf-8')
+        except KeyError:
+            return 
+
+        # load debugger from target dictionary or use default debugger
+        try:
+            debugger_dic = pro_def.get_debugger(expanded_dic['target'])
+            if debugger_dic is None:
+                debugger_name = self.definitions.debuggers_default
+            else:
+                debugger_name = debugger_dic['name']
+            uvoptx_dic['ProjectOpt']['Target']['TargetOption']['DebugOpt']['nTsel'] = self.definitions.debuggers[debugger_name]['uvoptx']['DebugOpt']['nTsel']
+            uvoptx_dic['ProjectOpt']['Target']['TargetOption']['DebugOpt']['pMon'] = self.definitions.debuggers[debugger_name]['uvoptx']['DebugOpt']['pMon']
+            uvoptx_dic['ProjectOpt']['Target']['TargetOption']['TargetDriverDllRegistry']['SetRegEntry']['Key'] = self.definitions.debuggers[debugger_name]['uvoptx']['SetRegEntry']['Key']
+        except KeyError:
+            raise RuntimeError("Debugger %s is not supported" % expanded_dic['debugger'])
 
     def _export_single_project(self, tool_name):
         expanded_dic = self.workspace.copy()
@@ -345,15 +454,31 @@ class Uvision(Tool, Builder, Exporter):
         # load debugger
         if expanded_dic['debugger']:
             try:
-                uvproj_dic['Project']['Targets']['Target']['TargetOption']['DebugOption']['TargetDlls']['Driver'] = self.definitions.debuggers[expanded_dic['debugger']]['TargetDlls']['Driver']
-                uvproj_dic['Project']['Targets']['Target']['TargetOption']['Utilities']['Flash2'] = self.definitions.debuggers[expanded_dic['debugger']]['Utilities']['Flash2']
+                uvproj_dic['Project']['Targets']['Target']['TargetOption']['DebugOption']['TargetDlls']['Driver'] = self.definitions.debuggers[expanded_dic['debugger']]['uvproj']['TargetDlls']['Driver']
+                uvproj_dic['Project']['Targets']['Target']['TargetOption']['Utilities']['Flash2'] = self.definitions.debuggers[expanded_dic['debugger']]['uvproj']['Utilities']['Flash2']
             except KeyError:
                 raise RuntimeError("Debugger %s is not supported" % expanded_dic['debugger'])
 
         # Project file
         uvproj_xml = xmltodict.unparse(uvproj_dic, pretty=True)
-        path, files = self.gen_file_raw(uvproj_xml, '%s.%s' % (expanded_dic['name'], extension), expanded_dic['output_dir']['path'])
-        return path, files
+        project_path, uvproj = self.gen_file_raw(uvproj_xml, '%s.%s' % (expanded_dic['name'], extension), expanded_dic['output_dir']['path'])
+
+        uvoptx = None
+        if tool_name == 'uvision5':
+
+            # generic tool template specified
+            uvoptx_dic = self.definitions.uvoptx_file
+
+            self._uvoptx_set_debugger(expanded_dic, uvoptx_dic, tool_name)
+
+            # set target only if defined, otherwise use from template/default one
+            extension = 'uvoptx'
+
+            # Project file
+            uvoptx_xml = xmltodict.unparse(uvoptx_dic, pretty=True)
+            project_path, uvoptx = self.gen_file_raw(uvoptx_xml, '%s.%s' % (expanded_dic['name'], extension), expanded_dic['output_dir']['path'])
+
+        return project_path, [uvproj, uvoptx]
 
     def export_workspace(self):
         path, workspace = self._generate_uvmpw_file()
@@ -363,7 +488,7 @@ class Uvision(Tool, Builder, Exporter):
         path, files = self._export_single_project('uvision') #todo: uvision will switch to uv4
         generated_projects = copy.deepcopy(self.generated_project)
         generated_projects['path'] = path
-        generated_projects['files']['uvproj'] = files
+        generated_projects['files']['uvproj'] = files[0]
         return generated_projects
 
     def get_generated_project_files(self):
@@ -409,6 +534,7 @@ class Uvision5(Uvision):
         'path': '',
         'files': {
             'uvprojx': '',
+            'uvoptx': '',
         }
     }
 
@@ -423,11 +549,12 @@ class Uvision5(Uvision):
         path, files = self._export_single_project('uvision5')
         generated_projects = copy.deepcopy(self.generated_project)
         generated_projects['path'] = path
-        generated_projects['files']['uvprojx'] = files
+        generated_projects['files']['uvprojx'] = files[0]
+        generated_projects['files']['uvoptx'] = files[1]
         return generated_projects
 
     def get_generated_project_files(self):
-        return {'path': self.workspace['path'], 'files': [self.workspace['files']['uvprojx']]}
+        return {'path': self.workspace['path'], 'files': [self.workspace['files']['uvprojx'], self.workspace['files']['uvoptx']]}
 
     def build_project(self):
         # tool_name uvision as uv4 is still used in uv5

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -131,56 +131,9 @@ class Uvision(Tool, Builder, Exporter):
     def get_toolchain():
         return 'uvision'
 
-    def _expand_data(self, old_data, new_data, attribute, group):
-        """ data expansion - uvision needs filename and path separately. """
-        if group == 'Sources':
-            old_group = None
-        else:
-            old_group = group
-        for file in old_data[old_group]:
-            if file:
-                extension = file.split(".")[-1].lower()
-                if not extension in self.file_types.keys():
-                    logger.debug("Filetype for file %s not recognized" % file)
-                    continue
-                new_file = {"FilePath": file, "FileName": basename(file),
+    def _expand_one_file(self, source, new_data, extension):
+        return {"FilePath": source, "FileName": basename(source),
                             "FileType": self.file_types[extension]}
-                new_data['groups'][group].append(new_file)
-
-    def _iterate(self, data, expanded_data):
-        """ Iterate through all sources/includes, store the result expansion in extended dictionary. """
-        for attribute in SOURCE_KEYS:
-            for k, v in data[attribute].items():
-                if k == None:
-                    group = 'Sources'
-                else:
-                    group = k
-                self._expand_data(data[attribute], expanded_data, attribute, group)
-        for k, v in data['include_files'].items():
-            if k == None:
-                group = 'Includes'
-            else:
-                group = k
-            self._expand_data(data['include_files'], expanded_data, attribute, group)
-
-        # sort groups
-        expanded_data['groups'] = OrderedDict(sorted(expanded_data['groups'].items(), key=lambda t: t[0]))
-
-    def _get_groups(self, data):
-        """ Get all groups defined. """
-        groups = []
-        for attribute in SOURCE_KEYS:
-            for k, v in data[attribute].items():
-                if k == None:
-                    k = 'Sources'
-                if k not in groups:
-                    groups.append(k)
-            for k, v in data['include_files'].items():
-                if k == None:
-                    k = 'Includes'
-                if k not in groups:
-                    groups.append(k)
-        return groups
 
     def _normalize_mcu_def(self, mcu_def):
         for k, v in mcu_def['TargetOption'].items():

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -301,7 +301,7 @@ class Uvision(Tool, Builder, Exporter):
                 if os.path.splitext(template)[1] == '.uvproj' or os.path.splitext(template)[1] == '.uvprojx' or \
                     re.match('.*\.uvproj.tmpl$', template) or re.match('.*\.uvprojx.tmpl$', template):
                     try:
-                        uvproj_dic = xmltodict.parse(open(template))
+                        uvproj_dic = xmltodict.parse(open(template, encoding="utf8").read())
                     except IOError:
                         logger.info("Template file %s not found. Using default template" % template)
                         uvproj_dic = self.definitions.uvproj_file

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -19,6 +19,7 @@ import logging
 import xmltodict
 import copy
 import re
+from codecs import open
 
 from os import getcwd
 from os.path import basename, join, normpath
@@ -287,7 +288,7 @@ class Uvision(Tool, Builder, Exporter):
                 if os.path.splitext(template)[1] == '.uvproj' or os.path.splitext(template)[1] == '.uvprojx' or \
                     re.match('.*\.uvproj.tmpl$', template) or re.match('.*\.uvprojx.tmpl$', template):
                     try:
-                        uvproj_dic = xmltodict.parse(open(template))
+                        uvproj_dic = xmltodict.parse(open(template, encoding="utf8").read())
                     except IOError:
                         logger.info("Template file %s not found" % template)
                         return None, None

--- a/project_generator/util.py
+++ b/project_generator/util.py
@@ -89,6 +89,8 @@ class PartialFormatter(string.Formatter):
         return val
 
 def strip_start(text, prefix):
+    if text == [] :
+        return []
     if not text.startswith(prefix):
         return text
     return text[len(prefix):]

--- a/project_generator/util.py
+++ b/project_generator/util.py
@@ -88,6 +88,11 @@ class PartialFormatter(string.Formatter):
             val = '{' + field_name + '}', first
         return val
 
+def strip_start(text, prefix):
+    if not text.startswith(prefix):
+        return text
+    return text[len(prefix):]
+
 def fix_paths(project_data, rel_path, extensions):
     """ Fix paths for extension list """
     norm_func = lambda path : os.path.normpath(os.path.join(rel_path, path))

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements = [str(requirement.req) for requirement in parse_requirements('requ
 
 setup(
     name='project_generator',
-    version='0.9.4',
+    version='0.9.5',
     description='Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!',
     author='Martin Kojtal',
     author_email='c0170@rocketmail.com',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements = [str(requirement.req) for requirement in parse_requirements('requ
 
 setup(
     name='project_generator',
-    version='0.9.7',
+    version='0.9.8',
     description='Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!',
     author='Martin Kojtal',
     author_email='c0170@rocketmail.com',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements = [str(requirement.req) for requirement in parse_requirements('requ
 
 setup(
     name='project_generator',
-    version='0.9.5',
+    version='0.9.6',
     description='Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!',
     author='Martin Kojtal',
     author_email='c0170@rocketmail.com',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements = [str(requirement.req) for requirement in parse_requirements('requ
 
 setup(
     name='project_generator',
-    version='0.9.6',
+    version='0.9.7',
     description='Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!',
     author='Martin Kojtal',
     author_email='c0170@rocketmail.com',


### PR DESCRIPTION
The build directory is now structured to exactly match the source directory.
This follows the principal of least surprise and allows the programmer of additional rules to elide some of the details as to how to locate sources.

Additional Targets (rules, actually) are now supported in all makefile-based templates.
For example to add the rule

``` GNUMake
$(OBJ_FOLDER)source/daplink/daplink.ld : source/daplink/daplink.lds | create_outputdir
    arm-none-eabi-cpp $^ -o $@ $(COMMON_FLAGS) $(INC_DIRS_F)"
```

to pre-process the linker script with the c pre-processor, one would have a configuration file like so:

``` YAML
tool_specific:
    make_gcc_arm:
        mcu:
            - cortex-m0
        linker_file: "$(OBJ_FOLDER)source/daplink/daplink.ld"
        misc:
            additional_targets:
                - "$(OBJ_FOLDER)source/daplink/daplink.ld : source/daplink/daplink.lds | create_outputdir \n\tarm-none-eabi-cpp $^ -o $@ $(COMMON_FLAGS) $(INC_DIRS_F)"
```
