### PR TITLE
Change include paths from YAML to unix paths before parsing.

### DIFF
--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -304,6 +304,7 @@ class Project:
             self.project['export']['include_files'][use_group_name] = []
 
         for include_file in use_includes:
+            include_file = include_file.replace('\\', '/')
             # include might be set to None - empty yaml list
             if include_file:
                 if os.path.isdir(include_file):


### PR DESCRIPTION
This allows all OSes to understand the include paths. os.path.normpath will take
care of changing it back to using backslashes if running on Windows.

Fixes #397.

(Note: This breaks obscure paths that actually contain backslashes in the file names, but I'd consider that an acceptable tradeoff)

@0xc0170 