### PR TITLE
Switch to codecs for open

### DIFF
--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -288,7 +288,7 @@ class Uvision(Tool, Builder, Exporter):
                 if os.path.splitext(template)[1] == '.uvproj' or os.path.splitext(template)[1] == '.uvprojx' or \
                     re.match('.*\.uvproj.tmpl$', template) or re.match('.*\.uvprojx.tmpl$', template):
                     try:
-                        uvproj_dic = xmltodict.parse(open(template))
+                        uvproj_dic = xmltodict.parse(open(template, encoding="utf8").read())
                     except IOError:
                         logger.info("Template file %s not found" % template)
                         return None, None

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -19,6 +19,7 @@ import logging
 import xmltodict
 import copy
 import re
+from codecs import open
 
 from os import getcwd
 from os.path import basename, join, normpath


### PR DESCRIPTION
It's backwards compatible with python 2.7, and forward compatible with python 3


I was able to reproduce the second error in #407 from within DAPLink:
```
$ progen generate -t uvision
Traceback (most recent call last):
  File "/usr/local/bin/progen", line 9, in <module>
    load_entry_point('project-generator==0.9.6', 'console_scripts', 'progen')()
  File "/usr/local/lib/python2.7/dist-packages/project_generator-0.9.6-py2.7.egg/project_generator/main.py", line 62, in main
    return args.func(args)
  File "/usr/local/lib/python2.7/dist-packages/project_generator-0.9.6-py2.7.egg/project_generator/commands/generate.py", line 29, in run
    if project.generate(args.tool, copied=args.copy, copy=args.copy) == -1:
  File "/usr/local/lib/python2.7/dist-packages/project_generator-0.9.6-py2.7.egg/project_generator/project.py", line 576, in generate
    files = exporter(self.project['export'], self.settings).export_project()
  File "/usr/local/lib/python2.7/dist-packages/project_generator-0.9.6-py2.7.egg/project_generator/tools/uvision.py", line 362, in export_project
    path, files = self._export_single_project('uvision') #todo: uvision will switch to uv4
  File "/usr/local/lib/python2.7/dist-packages/project_generator-0.9.6-py2.7.egg/project_generator/tools/uvision.py", line 304, in _export_single_project
    uvproj_dic = xmltodict.parse(open(template, encoding="utf8").read())
TypeError: 'encoding' is an invalid keyword argument for this function
```

this patch fixes that second issue.