### PR TITLE
iar - fix conditions for template parsing

### DIFF
--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -395,14 +395,13 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                     except IOError:
                         logger.info("Template file %s not found" % template)
                         ewd_dic = self.definitions.ewd_file
-                if not template_ewp and not template_ewd:
-                    logger.info("Template file %s contains unknown template extension (.ewp, .ewd are valid)" % template)
-                    if not template_ewp and template_ewd:
-                        ewp_dic, _ = self._get_default_templates() 
-                    elif not template_ewd and template_ewp:
-                        _, ewd_dic = self._get_default_templates()
-                    else:
-                        ewp_dic, ewd_dic = self._get_default_templates()
+                # handle non valid template files or not specified
+                if not template_ewp and template_ewd:
+                    ewp_dic, _ = self._get_default_templates() 
+                elif not template_ewd and template_ewp:
+                    _, ewd_dic = self._get_default_templates()
+                else:
+                    ewp_dic, ewd_dic = self._get_default_templates()
         elif 'iar' in self.env_settings.templates.keys():
             template_ewp = False
             template_ewd = False
@@ -423,12 +422,13 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                         template_ewd = True
                     except IOError:
                         logger.info("Template file %s not found" % template)
-                        ewd_dic = self.definitions.ewd_file
+                        ewd_dic = self.definitions.ewd_filele
+                # handle non valid template files or not specified
+                if not template_ewp and template_ewd:
+                    ewp_dic, _ = self._get_default_templates() 
+                elif not template_ewd and template_ewp:
+                    _, ewd_dic = self._get_default_templates()
                 else:
-                    # load default ewd if not found in the templates
-                    ewd_dic = self.definitions.ewd_file
-                if not template_ewp and not template_ewd:
-                    logger.info("Template file %s contains unknown template extension (.ewp, .ewd are valid)" % template)
                     ewp_dic, ewd_dic = self._get_default_templates()
         else:
             ewp_dic, ewd_dic = self._get_default_templates()


### PR DESCRIPTION
Logging was not correct, as template is not required. Use default, if none
is found.

Load template based on not found templates in the list of templates

@sarahmarshy 