### PR TITLE
Switch armasm preprocessor defines and print_info depend on executable

### DIFF
--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -150,7 +150,7 @@ $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS
 	@echo 'Finished building target: $@'
 	@echo ' '
 
-print_info:
+print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	@echo 'Printing size'
 	$(SIZE) --totals $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	$(OBJCOPY) {% block TOHEX %}{% endblock %} $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) {% block objcopy_output %}{% endblock %} $(OBJ_FOLDER)$(TARGET).hex
@@ -166,7 +166,7 @@ $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Finished building library: $@'
 	@echo ' '
 
-print_info:
+print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	@echo 'Printing size'
 	$(SIZE) --totals $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	@echo ' '

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -13,4 +13,4 @@
 
 {% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
-{% block ASM_SYMBOLS %}{% for symbol in macros %} --d "{{ morph_define(symbol) }}" {% endfor %}{% endblock %}
+{% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}

--- a/project_generator/tools/makearmcc.py
+++ b/project_generator/tools/makearmcc.py
@@ -38,12 +38,3 @@ class MakefileArmcc(MakefileTool):
         self.process_data_for_makefile(self.workspace)
         generated_projects['path'], generated_projects['files']['makefile'] = self.gen_file_jinja('makefile_armcc.tmpl', self.workspace, 'Makefile', self.workspace['output_dir']['path'])
         return generated_projects
-
-    def process_data_for_makefile(self, project_data):
-        def morph_define (define) :
-            if '=' in define :
-                return define.replace("=", " SETA ")
-            else :
-                return define + " SETA 1 "
-        project_data['morph_define'] = morph_define
-        MakefileTool.process_data_for_makefile(self, project_data)


### PR DESCRIPTION
These changes are required to get DAPLink to build with the make_armcc
toolchain in maximum parallel mode on Windows and Linux. Tested on
DAPLink make-armcc branch by @c1728p9 and me on Windows and Linux
respectively.