### PR TITLE
Remove setup.py pip dependency, fixes broken pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 import os
-import pip
 
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    with open(os.path.join(os.path.dirname(__file__), fname), 'r') as f:
+        return f.read()
 
-requirements = [str(requirement.req) for requirement in parse_requirements('requirements.txt', session=pip.download.PipSession())]
+def read_requirements():
+    req_lines = read('requirements.txt').splitlines()
+    return [req for req in req_lines if len(req) > 0 and not req.startswith("#")]
 
 setup(
     name='project_generator',
@@ -48,6 +49,6 @@ setup(
         ]
     },
 
-    install_requires = requirements,
+    install_requires = read_requirements(),
     include_package_data = True,
 )


### PR DESCRIPTION
Right now an up-to-date v10 pip install of this package, or any package that depends on project_generator will fail, as described in #440. 

Is discouraged to use pip internals and v10.0.0 has moved things around, so read the requirements.txt file directly.

