### PR TITLE
Fix iterating over a dictionary while removing elements

### DIFF
--- a/project_generator/tools/coide.py
+++ b/project_generator/tools/coide.py
@@ -204,13 +204,13 @@ class Coide(Tool, Exporter, Builder):
             logger.debug("Mcu definitions: %s" % mcu_def_dic)
             # correct attributes from definition, as yaml does not allowed multiple keys (=dict), we need to
             # do this magic.
-            for k, v in mcu_def_dic['Device'].items():
+            for k, v in dict(mcu_def_dic['Device']).items():
                 del mcu_def_dic['Device'][k]
                 mcu_def_dic['Device']['@' + k] = str(v)
             memory_areas = []
             for k, v in mcu_def_dic['MemoryAreas'].items():
                 # ??? duplicate use of k
-                for k, att in v.items():
+                for k, att in dict(v).items():
                     del v[k]
                     v['@' + k] = str(att)
                 memory_areas.append(v)


### PR DESCRIPTION
Do not attempt to delete directly from dictionary whilst iterating over it.

Issue reported and patch created by Matthias Klose from the Ubuntu [1] (and Debian [2]) Python Teams.

[1] http://launchpadlibrarian.net/449967823/python-project-generator_0.9.13-1_0.9.13-1ubuntu1.diff.gz
[2] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=944159

I'm forwarding the patch as the primary maintainer of the project_generator package on Debian.