### PR TITLE
makefile: fix include groups

### DIFF
--- a/project_generator/tools/makefile.py
+++ b/project_generator/tools/makefile.py
@@ -89,9 +89,12 @@ class MakefileTool(Tool, Exporter):
         return {'path': self.workspace['path'], 'files': [self.workspace['files']['makefile']]}
 
     def process_data_for_makefile(self, project_data):
-        #Flatten our dictionary, we don't need groups
+        # Flatten source dictionaries, we don't need groups
         for key in SOURCE_KEYS:
             project_data[key] = list(chain(*project_data[key].values()))
+        # flatten also include files
+        project_data['include_files'] = list(chain(*project_data['include_files'].values()))
+
         self._get_libs(project_data)
         self._parse_specific_options(project_data)
 


### PR DESCRIPTION
I had a project with groups and makefile project just failed to compile

we flatten sources, but forgot to do for the includes as well