### PR TITLE
Makefile: add preprocessed linker script files

### DIFF
--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -44,13 +44,14 @@ TARGET_EXT = .a
 LD_SCRIPT = {{linker_file}}
 LINKER_EXT = {{linker_extension}}
 
-{% if preprocess_linker_file %}
-$(TARGET).linker_script$(LINKER_EXT): $(LD_SCRIPT)
-	@$(PREPROC) - < $< -o $@
-{% endif %}
 
 CC_SYMBOLS = {% for symbol in macros %} -D{{symbol}} {% endfor %}
 ASM_SYMBOLS = {% block ASM_SYMBOLS %}{% endblock %}
+
+{% if preprocess_linker_file %}
+$(TARGET).linker_script$(LINKER_EXT): $(LD_SCRIPT)
+	@$(PREPROC) $(CC_SYMBOLS) $(ASM_SYMBOLS) - < $< -o $@
+{% endif %}
 
 LIBS = {% for library in libraries %} -l{{library}} {% endfor %} 
 {% if standard_libraries %} 

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -52,10 +52,10 @@ LD_SCRIPT = {{linker_file}}
 CC_SYMBOLS = {% for symbol in macros %} -D{{symbol}} {% endfor %}
 ASM_SYMBOLS = {% block ASM_SYMBOLS %}{% endblock %}
 
-LIBS = {% for library in libraries %} -l{{library}} {% endfor %} 
-{% if standard_libraries %} 
+LIBS = {% for library in libraries %} -l{{library}} {% endfor %}
+{% if standard_libraries %}
 LIBS += -Wl,--start-group  {% for library in standard_libraries %} -l{{library}} {% endfor %} -Wl,--end-group
-{% endif %} 
+{% endif %}
 
 LIB_PATHS = {% for path in lib_paths %} -L{{path}} {% endfor %}
 
@@ -77,7 +77,7 @@ endif
 
 # Flags
 COMMON_FLAGS = {% for option in common_flags %} {{option}} {% endfor %}
-COMMON_FLAGS += {% block COMMON_FLAGS %}{% endblock %} 
+COMMON_FLAGS += {% block COMMON_FLAGS %}{% endblock %}
 
 C_FLAGS  = {% for option in c_flags %} {{option}} {% endfor %}
 CXX_FLAGS  = {% for option in cxx_flags %} {{option}} {% endfor %}
@@ -165,7 +165,7 @@ $(LD_SCRIPT): $(LD_SCRIPT_IN)
 $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: MCU Linker'
-	$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS) 
+	$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -46,7 +46,7 @@ LINKER_EXT = {{linker_extension}}
 
 {% if preprocess_linker_file %}
 $(TARGET).linker_script$(LINKER_EXT): $(LD_SCRIPT)
-	@$(PREPROC) $< -o $@
+	@$(PREPROC) - < $< -o $@
 {% endif %}
 
 CC_SYMBOLS = {% for symbol in macros %} -D{{symbol}} {% endfor %}

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -49,7 +49,7 @@ CC_SYMBOLS = {% for symbol in macros %} -D{{symbol}} {% endfor %}
 ASM_SYMBOLS = {% block ASM_SYMBOLS %}{% endblock %}
 
 {% if preprocess_linker_file %}
-$(TARGET).linker_script$(LINKER_EXT): $(LD_SCRIPT)
+$(TARGET).generated$(LINKER_EXT): $(LD_SCRIPT)
 	@$(PREPROC) $(CC_SYMBOLS) $< -o $@
 {% endif %}
 
@@ -158,7 +158,7 @@ endif
 {% if output_type == 'exe' %}
 
 # Tool invocations
-$(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): {% if preprocess_linker_file %} $(TARGET).linker_script$(LINKER_EXT) {% else %} $(LINKER_SCRIPT) {% endif %} $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
+$(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): {% if preprocess_linker_file %} $(TARGET).generated$(LINKER_EXT) {% else %} $(LINKER_SCRIPT) {% endif %} $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: MCU Linker'
 	$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS) 

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -41,17 +41,16 @@ TARGET_EXT = .elf
 TARGET_EXT = .a
 {% endif %}
 
-LD_SCRIPT = {{linker_file}}
 LINKER_EXT = {{linker_extension}}
-
+{% if preprocess_linker_file %}
+LD_SCRIPT_IN = {{linker_file}}
+LD_SCRIPT = $(OUT_DIR)/$(TARGET).generated$(LINKER_EXT)
+{% else %}
+LD_SCRIPT = {{linker_file}}
+{% endif %}
 
 CC_SYMBOLS = {% for symbol in macros %} -D{{symbol}} {% endfor %}
 ASM_SYMBOLS = {% block ASM_SYMBOLS %}{% endblock %}
-
-{% if preprocess_linker_file %}
-$(TARGET).generated$(LINKER_EXT): $(LD_SCRIPT)
-	@$(PREPROC) $(CC_SYMBOLS) $< -o $@
-{% endif %}
 
 LIBS = {% for library in libraries %} -l{{library}} {% endfor %} 
 {% if standard_libraries %} 
@@ -158,7 +157,12 @@ endif
 {% if output_type == 'exe' %}
 
 # Tool invocations
-$(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): {% if preprocess_linker_file %} $(TARGET).generated$(LINKER_EXT) {% else %} $(LINKER_SCRIPT) {% endif %} $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
+{% if preprocess_linker_file %}
+$(LD_SCRIPT): $(LD_SCRIPT_IN)
+	@$(PREPROC) $(INC_DIRS_F) $(CC_SYMBOLS) $< -o $@
+{% endif %}
+
+$(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: MCU Linker'
 	$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS) 

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -25,6 +25,7 @@ CXX = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block CXX %}{% endblock %}
 AS = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AS %}{% endblock %}
 LD = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block LD %}{% endblock %}
 AR = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AR %}{% endblock %}
+PREPROC = $(CC) -E -P
 
 SIZE = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN)size
 OBJCOPY = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block OBJCOPY %}{% endblock %}
@@ -41,6 +42,12 @@ TARGET_EXT = .a
 {% endif %}
 
 LD_SCRIPT = {{linker_file}}
+LINKER_EXT = {{linker_extension}}
+
+{% if preprocess_linker_file %}
+$(TARGET).linker_script$(LINKER_EXT): $(LD_SCRIPT)
+	@$(PREPROC) $< -o $@
+{% endif %}
 
 CC_SYMBOLS = {% for symbol in macros %} -D{{symbol}} {% endfor %}
 ASM_SYMBOLS = {% block ASM_SYMBOLS %}{% endblock %}
@@ -148,8 +155,9 @@ else
 endif
 
 {% if output_type == 'exe' %}
+
 # Tool invocations
-$(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
+$(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): {% if preprocess_linker_file %} $(TARGET).linker_script$(LINKER_EXT) {% else %} $(LINKER_SCRIPT) {% endif %} $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: MCU Linker'
 	$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS) 

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -25,7 +25,7 @@ CXX = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block CXX %}{% endblock %}
 AS = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AS %}{% endblock %}
 LD = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block LD %}{% endblock %}
 AR = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AR %}{% endblock %}
-PREPROC = $(CC) -E -P
+PREPROC = $(CC) -E -P -x c
 
 SIZE = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN)size
 OBJCOPY = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block OBJCOPY %}{% endblock %}
@@ -50,7 +50,7 @@ ASM_SYMBOLS = {% block ASM_SYMBOLS %}{% endblock %}
 
 {% if preprocess_linker_file %}
 $(TARGET).linker_script$(LINKER_EXT): $(LD_SCRIPT)
-	@$(PREPROC) $(CC_SYMBOLS) - < $< -o $@
+	@$(PREPROC) $(CC_SYMBOLS) $< -o $@
 {% endif %}
 
 LIBS = {% for library in libraries %} -l{{library}} {% endfor %} 

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -159,7 +159,7 @@ endif
 # Tool invocations
 {% if preprocess_linker_file %}
 $(LD_SCRIPT): $(LD_SCRIPT_IN)
-	@$(PREPROC) $(INC_DIRS_F) $(CC_SYMBOLS) $< -o $@
+	@$(PREPROC) $(INC_DIRS_F) $(CC_SYMBOLS) -MMD $< -o $@
 {% endif %}
 
 $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
@@ -200,3 +200,6 @@ clean:
 
 # Include dependencies
 -include $(ALL_OBJS:.o=.d)
+
+# Include the linker script
+-include $(LD_SCRIPT:.ld=.d)

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -50,7 +50,7 @@ ASM_SYMBOLS = {% block ASM_SYMBOLS %}{% endblock %}
 
 {% if preprocess_linker_file %}
 $(TARGET).linker_script$(LINKER_EXT): $(LD_SCRIPT)
-	@$(PREPROC) $(CC_SYMBOLS) $(ASM_SYMBOLS) - < $< -o $@
+	@$(PREPROC) $(CC_SYMBOLS) - < $< -o $@
 {% endif %}
 
 LIBS = {% for library in libraries %} -l{{library}} {% endfor %} 

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -10,5 +10,5 @@
 {% block TOBIN %}-O binary{% endblock %}
 
 {% block COMMON_FLAGS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -MMD -MP $(CC_SYMBOLS) {% endblock %}
-{% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T $(filter-out %.o, $^) {% endblock %}
+{% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT) {% endblock %}
 {% block ASM_SYMBOLS %}$(CC_SYMBOLS){% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -10,5 +10,5 @@
 {% block TOBIN %}-O binary{% endblock %}
 
 {% block COMMON_FLAGS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -MMD -MP $(CC_SYMBOLS) {% endblock %}
-{% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT){% endblock %}
+{% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T $(filter-out %.o, $^) {% endblock %}
 {% block ASM_SYMBOLS %}$(CC_SYMBOLS){% endblock %}

--- a/project_generator/tools/gccarm.py
+++ b/project_generator/tools/gccarm.py
@@ -23,6 +23,9 @@ class MakefileGccArm(MakefileTool):
 
     def __init__(self, workspace, env_settings):
         MakefileTool.__init__(self, workspace, env_settings, logging)
+        # enable preprocessing linker files for GCC ARM
+        self.workspace['preprocess_linker_file'] = True
+        self.workspace['linker_extension'] = '.ld'
 
     @staticmethod
     def get_toolnames():


### PR DESCRIPTION
Only enabled it for GCC ARM as that one should run it (armcc should do it based on the file pragmas as I recall, will test as well).

Tested on simple programs,  the generated linker script is in the project folder. It runs the preprocessor and gets CC symbols.

cc @flit Please review