### PR TITLE
Log project generation

### DIFF
--- a/project_generator/commands/build.py
+++ b/project_generator/commands/build.py
@@ -39,6 +39,10 @@ def run(args):
         return 0
 
 def setup(subparser):
+    subparser.add_argument('-v', dest='verbosity', action='count', default=0,
+                        help='Increase the verbosity of the output (repeat for more verbose output)')
+    subparser.add_argument('-q', dest='quietness', action='count', default=0,
+                        help='Decrease the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument(
         "-f", "--file", help="YAML projects file", default='projects.yaml',
         type=argparse_filestring_type)

--- a/project_generator/commands/clean.py
+++ b/project_generator/commands/clean.py
@@ -28,6 +28,10 @@ def run(args):
     return 0
 
 def setup(subparser):
+    subparser.add_argument('-v', dest='verbosity', action='count', default=0,
+                        help='Increase the verbosity of the output (repeat for more verbose output)')
+    subparser.add_argument('-q', dest='quietness', action='count', default=0,
+                        help='Decrease the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument("-f", "--file", help="YAML projects file", default='projects.yaml', type=argparse_filestring_type)
     subparser.add_argument("-p", "--project", required = True, help="Specify which project to be removed")
     subparser.add_argument(

--- a/project_generator/commands/generate.py
+++ b/project_generator/commands/generate.py
@@ -29,7 +29,7 @@ def run(args):
     generated = True
     for project in generator.generate(args.project):
         generated = False
-        if project.workspace_name is not None:
+        if hasattr(project, 'workspace_name') and (project.workspace_name is not None):
             logger.info("Generating %s for %s in workspace %s", args.tool, project.name, project.workspace_name)
         else:
             logger.info("Generating %s for %s", args.tool, project.name)

--- a/project_generator/commands/generate.py
+++ b/project_generator/commands/generate.py
@@ -18,6 +18,8 @@ from ..tools_supported import ToolsSupported
 from ..generate import Generator
 from . import argparse_filestring_type, argparse_string_type
 
+logger = logging.getLogger('progen.generate')
+
 help = 'Generate a project record'
 
 def run(args):
@@ -27,6 +29,10 @@ def run(args):
     generated = True
     for project in generator.generate(args.project):
         generated = False
+        if project.workspace_name is not None:
+            logger.info("Generating %s for %s in workspace %s", args.tool, project.name, project.workspace_name)
+        else:
+            logger.info("Generating %s for %s", args.tool, project.name)
         if project.generate(args.tool, copied=args.copy, copy=args.copy) == -1:
             export_failed = True
         if args.build:

--- a/project_generator/commands/generate.py
+++ b/project_generator/commands/generate.py
@@ -38,6 +38,10 @@ def run(args):
         return 0
 
 def setup(subparser):
+    subparser.add_argument('-v', dest='verbosity', action='count', default=0,
+                        help='Increase the verbosity of the output (repeat for more verbose output)')
+    subparser.add_argument('-q', dest='quietness', action='count', default=0,
+                        help='Decrease the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument(
         "-f", "--file", help="YAML projects file", default='projects.yaml', type=argparse_filestring_type)
     subparser.add_argument(

--- a/project_generator/commands/init.py
+++ b/project_generator/commands/init.py
@@ -32,6 +32,10 @@ def run(args):
 
 
 def setup(subparser):
+    subparser.add_argument('-v', dest='verbosity', action='count', default=0,
+                        help='Increase the verbosity of the output (repeat for more verbose output)')
+    subparser.add_argument('-q', dest='quietness', action='count', default=0,
+                        help='Decrease the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument(
         '-p', '--project', help='Project name')
     subparser.add_argument(

--- a/project_generator/commands/list_projects.py
+++ b/project_generator/commands/list_projects.py
@@ -48,6 +48,10 @@ def run(args):
 
 
 def setup(subparser):
+    subparser.add_argument('-v', dest='verbosity', action='count', default=0,
+                        help='Increase the verbosity of the output (repeat for more verbose output)')
+    subparser.add_argument('-q', dest='quietness', action='count', default=0,
+                        help='Decrease the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument("section", choices = ['targets','tools','projects'],
                            help="What section you would like listed", default='projects')
     subparser.add_argument("-f", "--file", help="YAML projects file", type=argparse_filestring_type)


### PR DESCRIPTION
Two related changes.
1. The `generate` command logs as each project is generated.
2. Copied the verbosity arguments (`-v` and `-q`) to each of the subparser, removed from top level parser. This fixes the arguments, so you can use `-q` to turn off project generation logging if desired.