### PR TITLE
Fix Eclipse project source file links

### DIFF
--- a/project_generator/templates/eclipse.project.tmpl
+++ b/project_generator/templates/eclipse.project.tmpl
@@ -27,7 +27,12 @@
 		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
 		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
 	</natures>
-	<linkedResources> {% for group_name,files in groups.items() %} {% for file in files %}
+	<linkedResources> {% for group_name,files in groups.items() %}
+		<link>
+			<name>{{group_name}}</name>
+			<type>2</type>
+			<locationURI>virtual:/virtual</locationURI>
+		</link> {% for file in files %}
 		<link>
 			<name>{{group_name}}/{{file.name}}</name>
 			<type>1</type>

--- a/project_generator/templates/eclipse_makefile.cproject.tmpl
+++ b/project_generator/templates/eclipse_makefile.cproject.tmpl
@@ -89,7 +89,7 @@
 							<option id="ilg.gnuarmeclipse.managedbuild.cross.option.debugging.gprof.217246092" name="Generate gprof information (-pg)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.debugging.gprof"/>
 							<option id="ilg.gnuarmeclipse.managedbuild.cross.option.debugging.other.747128841" name="Other debugging flags" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.debugging.other"/>
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="ilg.gnuarmeclipse.managedbuild.cross.targetPlatform.1813696294" isAbstract="false" osList="all" superClass="ilg.gnuarmeclipse.managedbuild.cross.targetPlatform"/>
-							<builder command="make" id="ilg.gnuarmeclipse.managedbuild.cross.builder.41233599" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="ilg.gnuarmeclipse.managedbuild.cross.builder"/>
+							<builder command="make" id="ilg.gnuarmeclipse.managedbuild.cross.builder.41233599" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="ilg.gnuarmeclipse.managedbuild.cross.builder"/>
 							<tool id="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.1673259568" name="Cross ARM GNU Assembler" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler">
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.usepreprocessor.1024998702" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.usepreprocessor" value="true" valueType="boolean"/>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input.1765163841" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input"/>

--- a/project_generator/tools/eclipse.py
+++ b/project_generator/tools/eclipse.py
@@ -53,8 +53,12 @@ class EclipseGnuARM(Tool, Exporter, Builder):
         return 'gcc_arm'
 
     def _expand_one_file(self, source, new_data, extension):
-        return {"path": join('PARENT-%s-PROJECT_LOC' % new_data['output_dir']['rel_path'], normpath(source)), "name": basename(
-                    source), "type": self.file_types[extension.lower()]}
+        # Remove rel prefix.
+        rel_path = new_data['output_dir']['rel_path']
+        if source.startswith(rel_path):
+            non_rel_source = source[len(rel_path):]
+        return {"path": join('PARENT-%s-PROJECT_LOC' % new_data['output_dir']['rel_count'], normpath(non_rel_source)), "name": basename(
+                    non_rel_source), "type": self.file_types[extension.lower()]}
 
     def _expand_sort_key(self, file) :
         return file['name'].lower()


### PR DESCRIPTION
This patch fixes the generated file links in Eclipse projects. While source files show up in Eclipse projects, double clicking on them fails to load the fail and produces an error. 

I also threw in a change to enable parallel make builds from Eclipse by default.