### PR TITLE
More options for build command

### DIFF
--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -105,7 +105,7 @@ class ProjectWorkspace:
             self.generated_files[export_tool] = generated_files
             return result
 
-    def build(self, tool):
+    def build(self, tool, **kwargs):
         logger.info("Building a workspace is not currently supported")
         return -1
 
@@ -177,7 +177,7 @@ class Project:
     def __init__(self, name, project_dicts, settings, workspace_name=None):
         """ Initialise a project with a yaml file """
 
-        assert type(project_dicts) is list, "Project records/dics must be a list" % project_dicts 
+        assert type(project_dicts) is list, "Project records/dics must be a list" % project_dicts
 
         self.settings = settings
         self.name = name
@@ -452,7 +452,7 @@ class Project:
         for key in SOURCE_KEYS:
             self.project['export'][key] = merge_recursive(self.project['export'][key], tool_sources[key])
             # sort all sources within its own group and own category (=k)
-            # the tool needs to do sort files as tools require further processing based on 
+            # the tool needs to do sort files as tools require further processing based on
             # categories (we can't mix now cpp and c files for instance)
             for k, v in self.project['export'][key].items():
                 self.project['export'][key][k] = sorted(v, key=lambda x: os.path.basename(x))
@@ -554,7 +554,7 @@ class Project:
         self.generated_files = generated_files
         return result
 
-    def build(self, tool):
+    def build(self, tool, **kwargs):
         """build the project"""
 
         tools = self._validate_tools(tool)
@@ -573,7 +573,7 @@ class Project:
 
             logger.debug("Building for tool: %s", build_tool)
             logger.debug(self.generated_files)
-            if builder(self.generated_files[build_tool], self.settings).build_project() == -1:
+            if builder(self.generated_files[build_tool], self.settings).build_project(**kwargs) == -1:
                 # if one fails, set to -1 to report
                 result = -1
         return result

--- a/project_generator/tools/iar.py
+++ b/project_generator/tools/iar.py
@@ -100,7 +100,7 @@ class IAREmbeddedWorkbenchProject:
 
     def _get_option(self, settings, find_key):
         """ Return index for provided key """
-        # This is used as in IAR template, everything 
+        # This is used as in IAR template, everything
         # is as an array with random positions. We look for key with an index
         for option in settings:
             if option['name'] == find_key:
@@ -252,11 +252,11 @@ class IAREmbeddedWorkbenchProject:
             except KeyError:
                 return None
 
-        # Get variant 
+        # Get variant
         Variant = _get_mcu_option('Variant')
         if not Variant:
             Variant = _get_mcu_option('CoreVariant')
-        GFPUCoreSlave = _get_mcu_option('GFPUCoreSlave') 
+        GFPUCoreSlave = _get_mcu_option('GFPUCoreSlave')
         if not GFPUCoreSlave:
             GFPUCoreSlave = _get_mcu_option('GFPUCoreSlave2')
         GBECoreSlave = _get_mcu_option('GBECoreSlave')
@@ -298,7 +298,7 @@ class IAREmbeddedWorkbenchProject:
         except TypeError as e:
             # use default
             pass
-        
+
 class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject):
 
     generated_project = {
@@ -388,7 +388,7 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                         ewd_dic = xmltodict.parse(open(self.ewd_file).read())
                 # handle non valid template files or not specified
                 if not template_ewp and template_ewd:
-                    ewp_dic, _ = self._get_default_templates() 
+                    ewp_dic, _ = self._get_default_templates()
                 elif not template_ewd and template_ewp:
                     _, ewd_dic = self._get_default_templates()
                 else:
@@ -416,7 +416,7 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
                         ewd_dic = xmltodict.parse(open(self.ewd_file).read())
                 # handle non valid template files or not specified
                 if not template_ewp and template_ewd:
-                    ewp_dic, _ = self._get_default_templates() 
+                    ewp_dic, _ = self._get_default_templates()
                 elif not template_ewd and template_ewp:
                     _, ewd_dic = self._get_default_templates()
                 else:
@@ -541,7 +541,7 @@ class IAREmbeddedWorkbench(Tool, Builder, Exporter, IAREmbeddedWorkbenchProject)
         generated_projects['files']['ewd'] = files[2]
         return generated_projects
 
-    def build_project(self):
+    def build_project(self, **kwargs):
         """ Build IAR project """
         # > IarBuild [project_path] -build [project_name]
         proj_path = join(getcwd(), self.workspace['files']['ewp'])

--- a/project_generator/tools/makefile.py
+++ b/project_generator/tools/makefile.py
@@ -121,7 +121,12 @@ class MakefileTool(Tool, Exporter):
         path = dirname(self.workspace['files']['makefile'])
         self.logging.debug("Building GCC ARM project: %s" % path)
 
-        args = ['make', 'all']
+        args = ['make']
+        try:
+            args += ['-j', str(kwargs['jobs'])]
+        except KeyError:
+            pass
+        args += ['all']
         self.logging.debug(args)
 
         try:

--- a/project_generator/tools/makefile.py
+++ b/project_generator/tools/makefile.py
@@ -29,7 +29,7 @@ from ..util import SOURCE_KEYS
 class MakefileTool(Tool, Exporter):
 
     ERRORLEVEL = {
-        0: 'no errors)',
+        0: 'no errors',
         1: 'targets not already up to date',
         2: 'errors'
     }
@@ -115,7 +115,7 @@ class MakefileTool(Tool, Exporter):
         if project_data['core'] == 'cortex-m0+':
             project_data['core'] = 'cortex-m0plus'
 
-    def build_project(self):
+    def build_project(self, **kwargs):
         # cwd: relpath(join(project_path, ("gcc_arm" + project)))
         # > make all
         path = dirname(self.workspace['files']['makefile'])

--- a/project_generator/tools/tool.py
+++ b/project_generator/tools/tool.py
@@ -97,7 +97,7 @@ class Tool(object):
 class Builder:
     """ Just a builder template to be subclassed """
 
-    def build_project(self):
+    def build_project(self, **kwargs):
         """ Should return 0 if built, otherwise return -1 """
         raise NotImplementedError
 

--- a/project_generator/tools/uvision.py
+++ b/project_generator/tools/uvision.py
@@ -209,7 +209,7 @@ class Uvision(Tool, Builder, Exporter):
         return 'uvision'
 
     def _expand_one_file(self, source, new_data, extension):
-        ordered = OrderedDict() 
+        ordered = OrderedDict()
         ordered["FileType"] = self.file_types[extension]
         ordered["FileName"] = basename(source)
         ordered["FilePath"] = source
@@ -362,7 +362,7 @@ class Uvision(Tool, Builder, Exporter):
             uvoptx_dic['ProjectOpt']['Target']['TargetName'] = expanded_dic['name']
             uvoptx_dic['ProjectOpt']['Target']['TargetOption']['TargetDriverDllRegistry']['SetRegEntry']['Name'] = str(mcu_def_dic['TargetOption']['FlashDriverDll'][0])
         except KeyError:
-            return 
+            return
 
         # load debugger from target dictionary or use default debugger
         try:
@@ -528,7 +528,7 @@ class Uvision(Tool, Builder, Exporter):
                 logger.info("Project: %s build succeeded with the status: %s" % (self.workspace['files'][extension], self.ERRORLEVEL.get(ret_code, "Unknown")))
                 return 0
 
-    def build_project(self):
+    def build_project(self, **kwargs):
         return self._build_project('uvision', 'uvproj')
 
 class Uvision5(Uvision):
@@ -559,6 +559,6 @@ class Uvision5(Uvision):
     def get_generated_project_files(self):
         return {'path': self.workspace['path'], 'files': [self.workspace['files']['uvprojx'], self.workspace['files']['uvoptx']]}
 
-    def build_project(self):
+    def build_project(self, **kwargs):
         # tool_name uvision as uv4 is still used in uv5
         return self._build_project('uvision', 'uvprojx')


### PR DESCRIPTION
- `-k`, `--clean` to clean the project before generating and building.
- `-x`, `--stop-on-failure` will abort building on the first failure.
- `-j`, `--jobs` lets you set the number of concurrent build jobs. This is currently only implemented for makefiles.

As part of this, the `Project.build()` and `Builder.build_project()` methods now take `**kwargs` to accept arbitrary builder options.