### PR TITLE
Makefile improvements

### DIFF
--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -79,6 +79,7 @@ ASM_FLAGS  = {% for option in asm_flags %} {{option}} {% endfor %}
 CFLAGS = $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS)
 CXXFLAGS = $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS)
 ASFLAGS = $(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS)
+NMFLAGS = -n -f posix -C -l
 
 # Linker options
 LD_OPTIONS += {% for option in ld_flags %} {{option}} {% endfor %}
@@ -160,8 +161,7 @@ print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	$(SIZE) --totals $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
 	$(OBJCOPY) {% block TOHEX %}{% endblock %} $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) {% block objcopy_output %}{% endblock %} $(OBJ_FOLDER)$(TARGET).hex
 	$(OBJCOPY) {% block TOBIN %}{% endblock %} -v $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) {{ self.objcopy_output() }} $(OBJ_FOLDER)$(TARGET).bin
-	-$(OBJDUMP) -D $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) > $(OBJ_FOLDER)$(TARGET).lst
-	-$(NM) $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) > $(OBJ_FOLDER)$(TARGET)-symbol-table.txt
+	-$(NM) $(NMFLAGS) $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) > $(OBJ_FOLDER)$(TARGET)-symbol-table.txt
 	@echo ' '
 
 {% else %}

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -106,6 +106,11 @@ S_OBJS += $(patsubst %.S,$(OBJ_FOLDER)%.o,$(filter %.S,$(notdir $(S_SRCS))))
 
 O_OBJS := {% for file in source_files_obj %} {{file}} {% endfor %}
 
+ALL_OBJS := $(C_OBJS) \
+	$(CPP_OBJS) \
+	$(S_OBJS) \
+	$(O_OBJS)
+
 VPATH := $(SRC_DIRS)
 
 $(OBJ_FOLDER)%.o : %.c
@@ -179,3 +184,6 @@ clean:
 	@echo ' '
 
 .PHONY: clean print_info
+
+# Include dependencies
+-include $(ALL_OBJS:.o=.d)

--- a/project_generator/tools/makefile.py
+++ b/project_generator/tools/makefile.py
@@ -91,9 +91,9 @@ class MakefileTool(Tool, Exporter):
     def process_data_for_makefile(self, project_data):
         # Flatten source dictionaries, we don't need groups
         for key in SOURCE_KEYS:
-            project_data[key] = list(chain(*project_data[key].values()))
+            project_data[key] = list(sorted(chain(*project_data[key].values())))
         # flatten also include files
-        project_data['include_files'] = list(chain(*project_data['include_files'].values()))
+        project_data['include_files'] = list(sorted(chain(*project_data['include_files'].values())))
 
         self._get_libs(project_data)
         self._parse_specific_options(project_data)


### PR DESCRIPTION
1. Include `.d` dependency files so include file dependencies are honoured to cause rebuilds.
2. Sort the source and include file lists as output in makefiles.

    `.o` order has an effect on the link. Because the file lists come from dictionaries, the iteration order is nondeterministic. This was causing builds to differ between project generations even with no source changes. It also caused _eclipse_make_gcc_arm_ and _make_gcc_arm_ to produce different build output for the same project.
3. Remove call to `objdump`.

    This was taking too long and wasn't useful. Much more useful is to generate listings for each compilation by adding `-Wa,-adln=$@.lst` to `common_flags`.
4. Change `nm` flags to include size ("posix" format) and source file and line number info.