### PR TITLE
More make updates

### DIFF
--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -37,9 +37,16 @@ INSTRUCTION_MODE = thumb
 TARGET = {{name}}
 {% if output_type == 'exe' %}
 TARGET_EXT = .elf
+# Executables also produce hex and binary outputs.
+ALL_TARGET_OUT_FILES = $(TARGET_OUT) $(TARGET_HEX) $(TARGET_BIN)
 {% else %}
 TARGET_EXT = .a
+ALL_TARGET_OUT_FILES = $(TARGET_OUT)
 {% endif %}
+
+TARGET_OUT = $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
+TARGET_HEX = $(OBJ_FOLDER)$(TARGET).hex
+TARGET_BIN = $(OBJ_FOLDER)$(TARGET).bin
 
 LINKER_EXT = {{linker_extension}}
 {% if preprocess_linker_file %}
@@ -144,8 +151,8 @@ $(OBJ_FOLDER)%.o : %.s
 
 PRE_BUILD_SCRIPT := $(shell{% for command in pre_build_script %} ../../../{{command}} && {% endfor %} true)
 
-all: create_outputdir $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) print_info
-	{% for command in post_build_script %} ../../../{{command}} && {% endfor %} true
+all: create_outputdir $(ALL_TARGET_OUT_FILES)
+	@{% for command in post_build_script %} ../../../{{command}} && {% endfor %} true
 
 create_outputdir:
 ifeq ($(OS),Windows_NT)
@@ -162,32 +169,31 @@ $(LD_SCRIPT): $(LD_SCRIPT_IN)
 	@$(PREPROC) $(INC_DIRS_F) $(CC_SYMBOLS) -MMD $< -o $@
 {% endif %}
 
-$(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
+$(TARGET_OUT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: MCU Linker'
 	$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS)
 	@echo 'Finished building target: $@'
 	@echo ' '
+	@$(SIZE) --totals $(TARGET_OUT)
+	@-$(NM) $(NMFLAGS) $(TARGET_OUT) > $(OBJ_FOLDER)$(TARGET)-symbol-table.txt
 
-print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
-	@echo 'Printing size'
-	$(SIZE) --totals $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
-	$(OBJCOPY) {% block TOHEX %}{% endblock %} $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) {% block objcopy_output %}{% endblock %} $(OBJ_FOLDER)$(TARGET).hex
-	$(OBJCOPY) {% block TOBIN %}{% endblock %} -v $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) {{ self.objcopy_output() }} $(OBJ_FOLDER)$(TARGET).bin
-	-$(NM) $(NMFLAGS) $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) > $(OBJ_FOLDER)$(TARGET)-symbol-table.txt
-	@echo ' '
+$(TARGET_HEX): $(TARGET_OUT)
+	@echo 'Converting $@'
+	@$(OBJCOPY) {% block TOHEX %}{% endblock %} $(TARGET_OUT) {% block objcopy_output %}{% endblock %} $(TARGET_HEX)
+
+$(TARGET_BIN): $(TARGET_OUT)
+	@echo 'Converting $@'
+	@$(OBJCOPY) {% block TOBIN %}{% endblock %} $(TARGET_OUT) {{ self.objcopy_output() }} $(TARGET_BIN)
 
 {% else %}
-$(OBJ_FOLDER)$(TARGET)$(TARGET_EXT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
+$(TARGET_OUT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@echo 'Building library: $@'
-	$(AR) rcs $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT) $(CPP_OBJS) $(C_OBJS) $(S_OBJS)
+	$(AR) rcs $(TARGET_OUT) $(CPP_OBJS) $(C_OBJS) $(S_OBJS)
 	@echo 'Finished building library: $@'
 	@echo ' '
+	@$(SIZE) --totals $(TARGET_OUT)
 
-print_info: $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
-	@echo 'Printing size'
-	$(SIZE) --totals $(OBJ_FOLDER)$(TARGET)$(TARGET_EXT)
-	@echo ' '
 {% endif %}
 
 # Other Targets

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -36,7 +36,7 @@ NM = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN)nm
 INSTRUCTION_MODE = thumb
 TARGET = {{name}}
 {% if output_type == 'exe' %}
-TARGET_EXT = .elf
+TARGET_EXT = {% block TARGET_EXE_EXT %}{% endblock %}
 # Executables also produce hex and binary outputs.
 ALL_TARGET_OUT_FILES = $(TARGET_OUT) $(TARGET_HEX) $(TARGET_BIN)
 {% else %}

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -240,10 +240,13 @@ $(OBJ_FOLDER)%.o : %.s
 
 PRE_BUILD_SCRIPT := $(shell{% for command in pre_build_script %} ../../../{{command}} && {% endfor %} true)
 
-all: create_outputdir $(ALL_TARGET_OUT_FILES)
+all: $(ALL_TARGET_OUT_FILES)
 	$(at){% for command in post_build_script %} ../../../{{command}} && {% endfor %} true
 
-create_outputdir:
+# Make the build directory an order-only prerequisite for everything that goes in it.
+$(ALL_TARGET_OUT_FILES) $(ALL_OBJS) $(LD_SCRIPT): | $(OUT_DIR)
+
+$(OUT_DIR):
 ifeq ($(OS),Windows_NT)
 	$(at)-mkdir $(OUT_DIR)
 else

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -25,7 +25,7 @@ CXX = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block CXX %}{% endblock %}
 AS = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AS %}{% endblock %}
 LD = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block LD %}{% endblock %}
 AR = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AR %}{% endblock %}
-PREPROC = $(CC) -E -P -x c
+CPP = $(CC) -E
 
 SIZE = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN)size
 OBJCOPY = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block OBJCOPY %}{% endblock %}
@@ -128,37 +128,118 @@ ALL_OBJS := $(C_OBJS) \
 
 VPATH := $(SRC_DIRS)
 
+#-------------------------------------------------------------------------------
+# Logging options
+#-------------------------------------------------------------------------------
+
+# Enable color output by default.
+USE_COLOR ?= 1
+
+# Normally, commands in recipes are prefixed with '@' so the command itself
+# is not echoed by make. But if VERBOSE is defined (set to anything non-empty),
+# then the '@' is removed from recipes. The 'at' variable is used to control
+# this.
+ifeq "$(VERBOSE)" "1"
+at :=
+else
+at := @
+endif
+
+# These colors must be printed with the printf command. echo won't handle the
+# escape sequences.
+color_default = \033[00m
+color_bold = \033[01m
+color_red = \033[31m
+color_green = \033[32m
+color_yellow = \033[33m
+color_blue = \033[34m
+color_magenta = \033[35m
+color_cyan = \033[36m
+color_orange = \033[38;5;172m
+color_light_blue = \033[38;5;039m
+color_gray = \033[38;5;008m
+color_purple = \033[38;5;097m
+
+ifeq "$(USE_COLOR)" "1"
+color_build := $(color_light_blue)
+color_c := $(color_green)
+color_cxx := $(color_green)
+color_cpp := $(color_orange)
+color_asm := $(color_magenta)
+color_ar := $(color_yellow)
+color_link := $(color_cyan)
+color_convert := $(color_gray)
+endif
+
+# Used in printmessage if the color args are not present.
+color_ :=
+
+# Use in recipes to print color messages if printing to a terminal. If
+# USE_COLOR is not set to 1, this reverts to a simple uncolorized printf.
+# A newline is added to the end of the printed message.
+#
+# Arguments:
+#  1 - name of the color variable (see above), minus the "color_" prefix
+#  2 - first colorized part of the message
+#  3 - first uncolorized part of the message
+#  4 - color name for second colorized message
+#  5 - second colorized message
+#  6 - second uncolorized part of the message
+#  7 - uncolorized prefix on the whole line; this is last because it is expected to be used rarely
+#
+# All arguments are optional.
+#
+# Use like:
+#  $(call printmessage,cyan,Building, remainder of the message...)
+ifeq "$(USE_COLOR)" "1"
+define printmessage
+if [ -t 1 ]; then printf "$(7)$(color_$(1))$(2)$(color_default)$(3)$(color_$(4))$(5)$(color_default)$(6)\n" ; \
+else printf "$(7)$(2)$(3)$(5)$(6)\n" ; fi
+endef
+else
+define printmessage
+printf "$(7)$(2)$(3)$(5)$(6)\n"
+endef
+endif
+
+#-------------------------------------------------------------------------------
+# Recipes
+#-------------------------------------------------------------------------------
+
+# Compile C sources.
 $(OBJ_FOLDER)%.o : %.c
-	@echo 'Building file: $(@F)'
-	@echo 'Invoking: MCU C Compiler'
-	$(CC) $(CFLAGS) $(COMMON_FLAGS) $< -o $@
-	@echo 'Finished building: $(@F)'
-	@echo ' '
+	@$(call printmessage,c,Compiling, $<)
+	$(at)$(CC) $(CFLAGS) $(COMMON_FLAGS) $< -o $@
 
+# Compile C++ sources.
 $(OBJ_FOLDER)%.o : %.cpp
-	@echo 'Building file: $(@F)'
-	@echo 'Invoking: MCU C++ Compiler'
-	$(CXX) $(CXXFLAGS) $(COMMON_FLAGS) $< -o $@
-	@echo 'Finished building: $(@F)'
-	@echo ' '
+	@$(call printmessage,cxx,Compiling, $<)
+	$(at)$(CXX) $(CXXFLAGS) $(COMMON_FLAGS) $< -o $@
 
+# Preprocess and assemble .S sources.
+$(OBJ_FOLDER)%.o : %.S
+	@$(call printmessage,asm,Assembling, $<)
+	$(at)$(AS) $(ASFLAGS) $(COMMON_FLAGS) $< -o $@
+
+# Assemble .s sources.
 $(OBJ_FOLDER)%.o : %.s
-	@echo 'Building file: $(@F)'
-	@echo 'Invoking: MCU Assembler'
-	$(AS) $(ASFLAGS) $(COMMON_FLAGS) $< -o $@
-	@echo 'Finished building: $(@F)'
-	@echo ' '
+	@$(call printmessage,asm,Assembling, $<)
+	$(at)$(AS) $(ASFLAGS) $(COMMON_FLAGS) $< -o $@
+
+#-------------------------------------------------------------------------------
+# Rules
+#-------------------------------------------------------------------------------
 
 PRE_BUILD_SCRIPT := $(shell{% for command in pre_build_script %} ../../../{{command}} && {% endfor %} true)
 
 all: create_outputdir $(ALL_TARGET_OUT_FILES)
-	@{% for command in post_build_script %} ../../../{{command}} && {% endfor %} true
+	$(at){% for command in post_build_script %} ../../../{{command}} && {% endfor %} true
 
 create_outputdir:
 ifeq ($(OS),Windows_NT)
-	-mkdir $(OUT_DIR)
+	$(at)-mkdir $(OUT_DIR)
 else
-	$(shell mkdir $(OBJ_FOLDER) 2>/dev/null)
+	$(at)$(shell mkdir $(OBJ_FOLDER) 2>/dev/null)
 endif
 
 {% if output_type == 'exe' %}
@@ -166,32 +247,28 @@ endif
 # Tool invocations
 {% if preprocess_linker_file %}
 $(LD_SCRIPT): $(LD_SCRIPT_IN)
-	@$(PREPROC) $(INC_DIRS_F) $(CC_SYMBOLS) -MMD $< -o $@
+	@$(call printmessage,cpp,Preprocessing, $<)
+	$(at)$(CPP) -x c -P $(INC_DIRS_F) $(CC_SYMBOLS) -MMD $< -o $@
 {% endif %}
 
 $(TARGET_OUT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
-	@echo 'Building target: $@'
-	@echo 'Invoking: MCU Linker'
-	$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS)
-	@echo 'Finished building target: $@'
-	@echo ' '
-	@$(SIZE) --totals $(TARGET_OUT)
-	@-$(NM) $(NMFLAGS) $(TARGET_OUT) > $(OBJ_FOLDER)$(TARGET)-symbol-table.txt
+	@$(call printmessage,link,Linking, $@)
+	$(at)$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS)
+	$(at)$(SIZE) --totals $(TARGET_OUT)
+	$(at)-$(NM) $(NMFLAGS) $(TARGET_OUT) > $(OBJ_FOLDER)$(TARGET)-symbol-table.txt
 
 $(TARGET_HEX): $(TARGET_OUT)
-	@echo 'Converting $@'
-	@$(OBJCOPY) {% block TOHEX %}{% endblock %} $(TARGET_OUT) {% block objcopy_output %}{% endblock %} $(TARGET_HEX)
+	@$(call printmessage,convert,Converting, $@)
+	$(at)@$(OBJCOPY) {% block TOHEX %}{% endblock %} $(TARGET_OUT) {% block objcopy_output %}{% endblock %} $(TARGET_HEX)
 
 $(TARGET_BIN): $(TARGET_OUT)
-	@echo 'Converting $@'
-	@$(OBJCOPY) {% block TOBIN %}{% endblock %} $(TARGET_OUT) {{ self.objcopy_output() }} $(TARGET_BIN)
+	@$(call printmessage,convert,Converting, $@)
+	$(at)@$(OBJCOPY) {% block TOBIN %}{% endblock %} $(TARGET_OUT) {{ self.objcopy_output() }} $(TARGET_BIN)
 
 {% else %}
 $(TARGET_OUT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
-	@echo 'Building library: $@'
-	$(AR) rcs $(TARGET_OUT) $(CPP_OBJS) $(C_OBJS) $(S_OBJS)
-	@echo 'Finished building library: $@'
-	@echo ' '
+	@$(call printmessage,ar,Archiving, $@)
+	$(at)$(AR) rcs $(TARGET_OUT) $(CPP_OBJS) $(C_OBJS) $(S_OBJS)
 	@$(SIZE) --totals $(TARGET_OUT)
 
 {% endif %}
@@ -199,7 +276,7 @@ $(TARGET_OUT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 # Other Targets
 clean:
 	@echo 'Removing entire out directory'
-	$(RM) $(TARGET)$(TARGET_EXT) $(TARGET).bin $(TARGET).map $(OBJ_FOLDER)*.* $(OBJ_FOLDER)
+	$(at)$(RM) $(TARGET)$(TARGET_EXT) $(TARGET).bin $(TARGET).map $(OBJ_FOLDER)*.* $(OBJ_FOLDER)
 	@echo ' '
 
 .PHONY: clean print_info

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -287,7 +287,7 @@ $(TARGET_OUT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 # Other Targets
 clean:
 	@echo 'Removing entire out directory'
-	$(at)$(RM) $(TARGET)$(TARGET_EXT) $(TARGET).bin $(TARGET).map $(OBJ_FOLDER)*.* $(OBJ_FOLDER)
+	$(at)$(RM) $(OBJ_FOLDER)* $(OBJ_FOLDER)
 	@echo ' '
 
 .PHONY: clean print_info

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -290,7 +290,17 @@ clean:
 	$(at)$(RM) $(OBJ_FOLDER)* $(OBJ_FOLDER)
 	@echo ' '
 
-.PHONY: clean print_info
+help:
+	@echo "Useful targets:"
+	@echo " - all (default)"
+	@echo " - clean"
+	@echo " - help"
+	@echo
+	@echo "Options:"
+	@echo " - VERBOSE={0|1} to show full command lines."
+	@echo " - USE_COLOR={0|1} to override color output."
+
+.PHONY: clean help
 
 # Include dependencies
 -include $(ALL_OBJS:.o=.d)

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -25,7 +25,7 @@ CXX = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block CXX %}{% endblock %}
 AS = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AS %}{% endblock %}
 LD = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block LD %}{% endblock %}
 AR = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AR %}{% endblock %}
-CPP = $(CC) -E
+CPP = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block CPP %}{% endblock %}
 
 SIZE = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN)size
 OBJCOPY = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block OBJCOPY %}{% endblock %}
@@ -98,6 +98,14 @@ NMFLAGS = -n -f posix -C -l
 # Linker options
 LD_OPTIONS += {% for option in ld_flags %} {{option}} {% endfor %}
 LD_OPTIONS += {% block LD_OPTIONS %}{% endblock %}
+
+# Flags to run only preprocessor
+CPP_FLAGS = {% block CPP_FLAGS %}{% endblock %}
+
+{% if preprocess_linker_file %}
+# Flags to preprocess the linker script
+LD_CPP_FLAGS = {% block LD_CPP_FLAGS %}{% endblock %}
+{% endif %}
 
 OBJCPFLAGS = -O ihex
 
@@ -248,7 +256,7 @@ endif
 {% if preprocess_linker_file %}
 $(LD_SCRIPT): $(LD_SCRIPT_IN)
 	@$(call printmessage,cpp,Preprocessing, $<)
-	$(at)$(CPP) -x c -P $(INC_DIRS_F) $(CC_SYMBOLS) -MMD $< -o $@
+	$(at)$(CPP) $(CPP_FLAGS) $(LD_CPP_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -MMD $< -o $@
 {% endif %}
 
 $(TARGET_OUT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -284,5 +284,7 @@ clean:
 # Include dependencies
 -include $(ALL_OBJS:.o=.d)
 
-# Include the linker script
--include $(LD_SCRIPT:.ld=.d)
+{% if preprocess_linker_file %}
+# Include the linker script dependencies
+-include $(LD_SCRIPT:{{linker_extension}}=.d)
+{% endif %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -5,6 +5,7 @@
 {% block AS %}armasm{% endblock %}
 {% block LD %}armlink{% endblock %}
 {% block AR %}armar{% endblock %}
+{% block CPP %}armcc{% endblock %}
 {% block OBJCOPY %}fromelf{% endblock %}
 
 {% block TOBIN %}--bin{% endblock %}
@@ -15,4 +16,5 @@
 
 {% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
+{% block CPP_FLAGS %}-E{% endblock %}
 {% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -11,6 +11,8 @@
 {% block TOHEX %}--i32{% endblock %}
 {% block objcopy_output %}--output{% endblock %}
 
+{% block TARGET_EXE_EXT %}.axf{% endblock %}
+
 {% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
 {% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -2,7 +2,7 @@
 
 {% block CC %}gcc{% endblock %}
 {% block CXX %}g++{% endblock %}
-{% block AS %}gcc -x assembler-with-cpp{% endblock %}
+{% block AS %}gcc{% endblock %}
 {% block LD %}gcc{% endblock %}
 {% block AR %}ar{% endblock %}
 {% block OBJCOPY %}objcopy{% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -5,7 +5,9 @@
 {% block AS %}gcc{% endblock %}
 {% block LD %}gcc{% endblock %}
 {% block AR %}ar{% endblock %}
+{% block CPP %}cpp{% endblock %}
 {% block OBJCOPY %}objcopy{% endblock %}
+
 {% block TOHEX %}-O ihex{% endblock %}
 {% block TOBIN %}-O binary{% endblock %}
 
@@ -13,4 +15,6 @@
 
 {% block COMMON_FLAGS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -MMD -MP $(CC_SYMBOLS) {% endblock %}
 {% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT) {% endblock %}
+{% block CPP_FLAGS %}-E{% endblock %}
+{% block LD_CPP_FLAGS %}-x c -P{% endblock %}
 {% block ASM_SYMBOLS %}$(CC_SYMBOLS){% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -9,6 +9,8 @@
 {% block TOHEX %}-O ihex{% endblock %}
 {% block TOBIN %}-O binary{% endblock %}
 
+{% block TARGET_EXE_EXT %}.elf{% endblock %}
+
 {% block COMMON_FLAGS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -MMD -MP $(CC_SYMBOLS) {% endblock %}
 {% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT) {% endblock %}
 {% block ASM_SYMBOLS %}$(CC_SYMBOLS){% endblock %}

--- a/project_generator/tools/makefile.py
+++ b/project_generator/tools/makefile.py
@@ -146,8 +146,7 @@ class MakefileTool(Tool, Exporter):
                                    (ret_code, self.workspace['files']['makefile']))
                 return -1
             else:
-
-
-                self.logging.info("Build succeeded with the status: %s" %
-                             self.ERRORLEVEL[ret_code])
+                name = os.path.basename(self.workspace['path'])
+                self.logging.info("Built %s with the status: %s" %
+                             (name, self.ERRORLEVEL[ret_code]))
                 return 0


### PR DESCRIPTION
- Hex and bin outputs have explicit rules.
- Removed print_info rule, merged into link rule.
- Simplified build output to a single line per operation, such as `Compiling foo/bar.c`. Full output can be enabled with `VERBOSE=1`.
- Colorized output. Enabled by default for ttys, can be disabled with `USE_COLOR=0`.
- Set the target exe extension by compiler, using `.axf` for armcc.
- Only include linker script dependencies if it is being preprocessed. This fixed make_armcc.
- More well defined C preprocessing flags.
- Use order-only prerequisite to create the build output directory.
- Cleaned up `rm` command in clean rule.
- Added a simple help rule.