### PR TITLE
Fix for makefile_armcc

### DIFF
--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -15,6 +15,6 @@
 {% block TARGET_EXE_EXT %}.axf{% endblock %}
 
 {% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
-{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
+{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) --predefine -D'{{macros|join("' --predefine -D'")}}' $(patsubst %,--predefine "%",$(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
-{% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}
+{% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D'{{macros|join("',-D'")}}'{% endblock %}


### PR DESCRIPTION
This is quoting problem for macros values that have spaces in them and double quotes around them