### PR TITLE
Add support for make_armclang

### DIFF
--- a/project_generator/commands/list_projects.py
+++ b/project_generator/commands/list_projects.py
@@ -28,13 +28,12 @@ def run(args):
         generator = Generator(args.file)
         for project in generator.generate():
             if args.section == 'targets':
-                print("%s supports: %s"%(project.project['name'], project.project['target']))
+                print("%s supports: %s" % (project.name, project.project['target']))
             elif args.section == 'projects':
                 print (project.name)
             elif args.section == 'tools':
-                tools = [tool for tool, value in project.tool_specific.items() if value.linker_file is not None]
-                tools = ", ".join(tools)
-                print("%s supports: %s\n"%(project.project['name'], tools))
+                tools = [tool for tool, value in project.project['tool_specific'].items() if value.get('linker_file')]
+                print("%s supports: %s" % (project.name, ", ".join(tools)))
     else:
         if args.section == 'targets':
             print("\nProgen supports the following targets:\n")

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -544,11 +544,9 @@ class Project:
                 dump_data['common'] = self.project['common']
                 dump_data['tool_specific'] = self.project['tool_specific']
                 dump_data['merged'] = self.project['export']
-                handler = logging.FileHandler(os.path.join(os.getcwd(), "%s.log" % self.name),"w", encoding=None, delay="true")
-                handler.setLevel(logging.DEBUG)
-                logger.addHandler(handler)
-                logger.debug("\n" + yaml.dump(dump_data))
-
+                log_path = os.path.join(os.getcwd(), "%s-dump.yaml" % self.name)
+                with open(log_path, 'w') as f:
+                    f.write(yaml.dump(dump_data))
             files = exporter(self.project['export'], self.settings).export_project()
             generated_files[export_tool] = files
         self.generated_files = generated_files

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -27,10 +27,10 @@ LD = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block LD %}{% endblock %}
 AR = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AR %}{% endblock %}
 CPP = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block CPP %}{% endblock %}
 
-SIZE = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN)size
 OBJCOPY = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block OBJCOPY %}{% endblock %}
 OBJDUMP = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN)objdump
-NM = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN)nm
+SIZE = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block SIZE %}{% endblock %}
+NM = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block NM %}{% endblock %}
 
 # application specific
 INSTRUCTION_MODE = thumb
@@ -93,6 +93,7 @@ ASM_FLAGS  = {% for option in asm_flags %} {{option}} {% endfor %}
 CFLAGS = {% block CFLAGS %}{% endblock %}
 CXXFLAGS = {% block CXXFLAGS %}{% endblock %}
 ASFLAGS = {% block ASFLAGS %}{% endblock %}
+SIZEFLAGS = {% block SIZEFLAGS %}{% endblock %}
 NMFLAGS = {% block NMFLAGS %}{% endblock %}
 
 # Linker options
@@ -265,8 +266,8 @@ $(LD_SCRIPT): $(LD_SCRIPT_IN)
 $(TARGET_OUT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@$(call printmessage,link,Linking, $@)
 	$(at)$(LD) $(LIB_PATHS) -o $@ $(CPP_OBJS) $(C_OBJS) $(S_OBJS) $(O_OBJS) $(LIBS) $(LD_OPTIONS)
-	$(at)$(SIZE) --totals $(TARGET_OUT)
-	$(at)-$(NM) $(NMFLAGS) $(TARGET_OUT) > $(OBJ_FOLDER)$(TARGET)-symbol-table.txt
+	$(at)$(SIZE) $(SIZEFLAGS) $(TARGET_OUT)
+	$(at)-$(NM) $(NMFLAGS) $(TARGET_OUT) {% block nm_output %}{% endblock %} $(OBJ_FOLDER)$(TARGET)-symbol-table.txt
 
 $(TARGET_HEX): $(TARGET_OUT)
 	@$(call printmessage,convert,Converting, $@)
@@ -280,7 +281,7 @@ $(TARGET_BIN): $(TARGET_OUT)
 $(TARGET_OUT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 	@$(call printmessage,ar,Archiving, $@)
 	$(at)$(AR) rcs $(TARGET_OUT) $(CPP_OBJS) $(C_OBJS) $(S_OBJS)
-	@$(SIZE) --totals $(TARGET_OUT)
+	@$(SIZE) $(SIZEFLAGS) $(TARGET_OUT)
 
 {% endif %}
 

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -90,10 +90,10 @@ C_FLAGS  = {% for option in c_flags %} {{option}} {% endfor %}
 CXX_FLAGS  = {% for option in cxx_flags %} {{option}} {% endfor %}
 ASM_FLAGS  = {% for option in asm_flags %} {{option}} {% endfor %}
 
-CFLAGS = $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS)
-CXXFLAGS = $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS)
-ASFLAGS = $(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS)
-NMFLAGS = -n -f posix -C -l
+CFLAGS = {% block CFLAGS %}{% endblock %}
+CXXFLAGS = {% block CXXFLAGS %}{% endblock %}
+ASFLAGS = {% block ASFLAGS %}{% endblock %}
+NMFLAGS = {% block NMFLAGS %}{% endblock %}
 
 # Linker options
 LD_OPTIONS += {% for option in ld_flags %} {{option}} {% endfor %}
@@ -213,27 +213,27 @@ endif
 #-------------------------------------------------------------------------------
 # Recipes
 #-------------------------------------------------------------------------------
-
+{% block RECIPES %}
 # Compile C sources.
 $(OBJ_FOLDER)%.o : %.c
 	@$(call printmessage,c,Compiling, $<)
-	$(at)$(CC) $(CFLAGS) $(COMMON_FLAGS) $< -o $@
+	$(at)$(CC) $(CFLAGS) $< -o $@
 
 # Compile C++ sources.
 $(OBJ_FOLDER)%.o : %.cpp
 	@$(call printmessage,cxx,Compiling, $<)
-	$(at)$(CXX) $(CXXFLAGS) $(COMMON_FLAGS) $< -o $@
+	$(at)$(CXX) $(CXXFLAGS) $< -o $@
 
 # Preprocess and assemble .S sources.
 $(OBJ_FOLDER)%.o : %.S
 	@$(call printmessage,asm,Assembling, $<)
-	$(at)$(AS) $(ASFLAGS) $(COMMON_FLAGS) $< -o $@
+	$(at)$(AS) $(ASFLAGS) $< -o $@
 
 # Assemble .s sources.
 $(OBJ_FOLDER)%.o : %.s
 	@$(call printmessage,asm,Assembling, $<)
-	$(at)$(AS) $(ASFLAGS) $(COMMON_FLAGS) $< -o $@
-
+	$(at)$(AS) $(ASFLAGS) $< -o $@
+{% endblock %}
 #-------------------------------------------------------------------------------
 # Rules
 #-------------------------------------------------------------------------------
@@ -300,7 +300,7 @@ help:
 	@echo " - VERBOSE={0|1} to show full command lines."
 	@echo " - USE_COLOR={0|1} to override color output."
 
-.PHONY: clean help
+.PHONY: all clean help
 
 # Include dependencies
 -include $(ALL_OBJS:.o=.d)

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -110,8 +110,6 @@ CPP_FLAGS = {% block CPP_FLAGS %}{% endblock %}
 LD_CPP_FLAGS = {% block LD_CPP_FLAGS %}{% endblock %}
 {% endif %}
 
-OBJCPFLAGS = -O ihex
-
 ARFLAGS = cr
 
 ifeq ($(OS),Windows_NT)
@@ -274,7 +272,7 @@ endif
 {% if preprocess_linker_file %}
 $(LD_SCRIPT): $(LD_SCRIPT_IN)
 	@$(call printmessage,cpp,Preprocessing, $<)
-	$(at)$(CPP) $(CPP_FLAGS) $(LD_CPP_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -MMD $< -o $@
+	$(at)$(CPP) $(CPP_FLAGS) $(LD_CPP_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) $< -o $@
 {% endif %}
 
 $(TARGET_OUT): $(LD_SCRIPT) $(C_OBJS) $(CPP_OBJS) $(S_OBJS)

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -28,7 +28,7 @@ AR = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block AR %}{% endblock %}
 CPP = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block CPP %}{% endblock %}
 
 OBJCOPY = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block OBJCOPY %}{% endblock %}
-OBJDUMP = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN)objdump
+OBJDUMP = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block OBJDUMP %}{% endblock %}
 SIZE = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block SIZE %}{% endblock %}
 NM = $(TOOLCHAIN_BINPATH)$(TOOLCHAIN){% block NM %}{% endblock %}
 
@@ -93,6 +93,8 @@ ASM_FLAGS  = {% for option in asm_flags %} {{option}} {% endfor %}
 CFLAGS = {% block CFLAGS %}{% endblock %}
 CXXFLAGS = {% block CXXFLAGS %}{% endblock %}
 ASFLAGS = {% block ASFLAGS %}{% endblock %}
+GENASMFLAGS = {% block GENASMFLAGS %}{% endblock %}
+OBJDUMPFLAGS = {% block OBJDUMPFLAGS %}{% endblock %}
 SIZEFLAGS = {% block SIZEFLAGS %}{% endblock %}
 NMFLAGS = {% block NMFLAGS %}{% endblock %}
 
@@ -218,12 +220,24 @@ endif
 # Compile C sources.
 $(OBJ_FOLDER)%.o : %.c
 	@$(call printmessage,c,Compiling, $<)
+ifeq ($(GENERATE_ASSEMBLY),1)
+	$(at)$(CC) $(CFLAGS) $(GENASMFLAGS) $<
+endif
 	$(at)$(CC) $(CFLAGS) $< -o $@
+ifeq ($(DISASSEMBLE_OBJECTS),1)
+	$(at)$(OBJDUMP) $(OBJDUMPFLAGS) $@ {% block objdump_output %}{% endblock %} $(@:%.o=%.lst)
+endif
 
 # Compile C++ sources.
 $(OBJ_FOLDER)%.o : %.cpp
 	@$(call printmessage,cxx,Compiling, $<)
+ifeq ($(GENERATE_ASSEMBLY),1)
+	$(at)$(CXX) $(CFLAGS) $(GENASMFLAGS) $<
+endif
 	$(at)$(CXX) $(CXXFLAGS) $< -o $@
+ifeq ($(DISASSEMBLE_OBJECTS),1)
+	$(at)$(OBJDUMP) $(OBJDUMPFLAGS) $@ {{ self.objdump_output() }} $(@:%.o=%.lst)
+endif
 
 # Preprocess and assemble .S sources.
 $(OBJ_FOLDER)%.o : %.S

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -251,10 +251,11 @@ $(OBJ_FOLDER)%.o : %.s
 # Rules
 #-------------------------------------------------------------------------------
 
-PRE_BUILD_SCRIPT := $(shell{% for command in pre_build_script %} ../../../{{command}} && {% endfor %} true)
+PRE_BUILD_SCRIPT :={% for command in pre_build_script %} \
+	$(shell {{output_dir.rel_path}}{{command}}){% endfor %}
 
-all: $(ALL_TARGET_OUT_FILES)
-	$(at){% for command in post_build_script %} ../../../{{command}} && {% endfor %} true
+all: $(ALL_TARGET_OUT_FILES){% for command in post_build_script %}
+	$(at)-{{output_dir.rel_path}}{{command}}{% endfor %}
 
 # Make the build directory an order-only prerequisite for everything that goes in it.
 $(ALL_TARGET_OUT_FILES) $(ALL_OBJS) $(LD_SCRIPT): | $(OUT_DIR)

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -200,6 +200,11 @@ color_ :=
 #
 # Use like:
 #  $(call printmessage,cyan,Building, remainder of the message...)
+ifeq ($(OS),Windows_NT)
+define printmessage
+echo "$(7)$(2)$(3)$(5)$(6)"
+endef
+else
 ifeq "$(USE_COLOR)" "1"
 define printmessage
 if [ -t 1 ]; then printf "$(7)$(color_$(1))$(2)$(color_default)$(3)$(color_$(4))$(5)$(color_default)$(6)\n" ; \
@@ -209,6 +214,7 @@ else
 define printmessage
 printf "$(7)$(2)$(3)$(5)$(6)\n"
 endef
+endif
 endif
 
 #-------------------------------------------------------------------------------

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -27,6 +27,6 @@
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c{% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c{% endblock %}
 {% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
-{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) --predefine -D'{{macros|join("' --predefine -D'")}}' $(patsubst %,--predefine "%",$(INC_DIRS_F)){% endblock %}
+{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) --map --list $(OBJ_FOLDER)$(TARGET).map --predefine -D'{{macros|join("' --predefine -D'")}}' $(patsubst %,--predefine "%",$(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
 {% block ASM_SYMBOLS %}--cpreproc --cpreproc_opts=-D'{{macros|join("',-D'")}}'{% endblock %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -7,12 +7,16 @@
 {% block AR %}armar{% endblock %}
 {% block CPP %}armcc{% endblock %}
 {% block OBJCOPY %}fromelf{% endblock %}
+{% block OBJDUMP %}fromelf{% endblock %}
 {% block SIZE %}fromelf{% endblock %}
 {% block NM %}fromelf{% endblock %}
 
 {% block TOBIN %}--bin{% endblock %}
 {% block TOHEX %}--i32{% endblock %}
 {% block objcopy_output %}--output{% endblock %}
+{% block objdump_output %}--output{% endblock %}
+{% block OBJDUMPFLAGS %}--text -acdyrz --interleave=source{% endblock %}
+{% block GENASMFLAGS %}-S -W{% endblock %}
 {% block SIZEFLAGS %}--text -z{% endblock %}
 {% block nm_output %}--output{% endblock %}
 {% block NMFLAGS %}--text -arz{% endblock %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -15,6 +15,10 @@
 {% block TARGET_EXE_EXT %}.axf{% endblock %}
 
 {% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
+{% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
+{% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
+{% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
+{% block NMFLAGS %}-n -f posix -C -l{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
 {% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -26,7 +26,7 @@
 {% block COMMON_FLAGS %}--cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c{% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c{% endblock %}
-{% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
+{% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS){% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) --map --list $(OBJ_FOLDER)$(TARGET).map --predefine -D'{{macros|join("' --predefine -D'")}}' $(patsubst %,--predefine "%",$(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
 {% block ASM_SYMBOLS %}--cpreproc --cpreproc_opts=-D'{{macros|join("',-D'")}}'{% endblock %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -27,6 +27,6 @@
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
 {% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
-{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
+{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) --predefine -D'{{macros|join("' --predefine -D'")}}' $(patsubst %,--predefine "%",$(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
-{% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}
+{% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D'{{macros|join("',-D'")}}'{% endblock %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -23,10 +23,10 @@
 
 {% block TARGET_EXE_EXT %}.axf{% endblock %}
 
-{% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
-{% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
-{% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
-{% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
+{% block COMMON_FLAGS %}--cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
+{% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c{% endblock %}
+{% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c{% endblock %}
+{% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) --predefine -D'{{macros|join("' --predefine -D'")}}' $(patsubst %,--predefine "%",$(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
-{% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D'{{macros|join("',-D'")}}'{% endblock %}
+{% block ASM_SYMBOLS %}--cpreproc --cpreproc_opts=-D'{{macros|join("',-D'")}}'{% endblock %}

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -7,10 +7,15 @@
 {% block AR %}armar{% endblock %}
 {% block CPP %}armcc{% endblock %}
 {% block OBJCOPY %}fromelf{% endblock %}
+{% block SIZE %}fromelf{% endblock %}
+{% block NM %}fromelf{% endblock %}
 
 {% block TOBIN %}--bin{% endblock %}
 {% block TOHEX %}--i32{% endblock %}
 {% block objcopy_output %}--output{% endblock %}
+{% block SIZEFLAGS %}--text -z{% endblock %}
+{% block nm_output %}--output{% endblock %}
+{% block NMFLAGS %}--text -arz{% endblock %}
 
 {% block TARGET_EXE_EXT %}.axf{% endblock %}
 
@@ -18,7 +23,6 @@
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
 {% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
-{% block NMFLAGS %}-n -f posix -C -l{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
 {% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -29,5 +29,5 @@
 # Add -Wa,armasm,--show_cmdline to ASFLAGS for armclang to display the armasm command
 {% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter=$(LD_SCRIPT) --map --list $(OBJ_FOLDER)$(TARGET).map{% endblock %}
-{% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=cortex-m4 -MMD{% endblock %}
+{% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=$(CPU) -MMD{% endblock %}
 {% block ASM_SYMBOLS %}${CC_SYMBOLS}{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -23,10 +23,10 @@
 
 {% block TARGET_EXE_EXT %}.axf{% endblock %}
 
-{% block COMMON_FLAGS %}{% endblock %}
-{% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
-{% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
-{% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
+{% block COMMON_FLAGS %}--target=arm-arm-none-eabi -mcpu=$(CPU) -m$(INSTRUCTION_MODE){% endblock %}
+{% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
+{% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
+{% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=star{% endblock %}
 {% block ASM_SYMBOLS %} -D"{{macros|join("\" -D\"")}}"{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -2,7 +2,7 @@
 
 {% block CC %}armclang{% endblock %}
 {% block CXX %}armclang{% endblock %}
-{% block AS %}armasm{% endblock %}
+{% block AS %}armclang{% endblock %}
 {% block LD %}armlink{% endblock %}
 {% block AR %}armar{% endblock %}
 {% block CPP %}armclang{% endblock %}
@@ -14,7 +14,38 @@
 
 {% block TARGET_EXE_EXT %}.axf{% endblock %}
 
-{% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
+{% block COMMON_FLAGS %}{% endblock %}
+{% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
+{% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
+{% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
+{% block NMFLAGS %}-n -f posix -C -l{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
-{% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}
+{% block LD_CPP_FLAGS %}-E -xc{% endblock %}
+{% block ASM_SYMBOLS %} -D"{{macros|join("\" -D\"")}}"{% endblock %}
+
+{% block RECIPES %}
+# Compile C sources.
+$(OBJ_FOLDER)%.o : %.c
+	@$(call printmessage,c,Compiling, $<)
+	$(at)$(CC) $(CFLAGS) $< -S -w -o $(@:%.o=%.S)
+	$(at)$(CC) $(CFLAGS) $< -o $@
+#	$(at)fromelf --text -acdyrz --interleave=source $@ > $(@:%.o=%.lst)
+
+# Compile C++ sources.
+$(OBJ_FOLDER)%.o : %.cpp
+	@$(call printmessage,cxx,Compiling, $<)
+	$(at)$(CXX) $(CXXFLAGS) $< -S -w -o $(@:%.o=%.S)
+	$(at)$(CXX) $(CXXFLAGS) $< -o $@
+#	$(at)fromelf -cdyrz --interleave=source $@ > $(@:%.o=%.lst)
+
+# Preprocess and assemble .S sources.
+$(OBJ_FOLDER)%.o : %.S
+	@$(call printmessage,asm,Assembling, $<)
+	$(at)$(AS) $(ASFLAGS) $< -o $@
+
+# Assemble .s sources.
+$(OBJ_FOLDER)%.o : %.s
+	@$(call printmessage,asm,Assembling, $<)
+	$(at)$(AS) $(ASFLAGS) $< -o $@
+{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -28,8 +28,7 @@
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
 {% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
-{% block CPP_FLAGS %}-E{% endblock %}
-{% block LD_CPP_FLAGS %}-E -xc{% endblock %}
+{% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=star{% endblock %}
 {% block ASM_SYMBOLS %} -D"{{macros|join("\" -D\"")}}"{% endblock %}
 
 {% block RECIPES %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -26,8 +26,8 @@
 {% block COMMON_FLAGS %}--target=arm-arm-none-eabi -mcpu=$(CPU) -m$(INSTRUCTION_MODE){% endblock %}
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
-# Add -Wa,armasm,--show_cmdline to debug calls to armasm through armclang
+# Add -Wa,armasm,--show_cmdline to ASFLAGS for armclang to display the armasm command
 {% block ASFLAGS %}-masm=auto -x assembler-with-cpp $(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter=$(LD_SCRIPT) --map --list $(OBJ_FOLDER)$(TARGET).map{% endblock %}
-{% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=star -MMD{% endblock %}
+{% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=cortex-m4 -MMD{% endblock %}
 {% block ASM_SYMBOLS %}${CC_SYMBOLS}{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -1,0 +1,20 @@
+{% extends "makefile.tmpl" %}
+
+{% block CC %}armclang{% endblock %}
+{% block CXX %}armclang{% endblock %}
+{% block AS %}armasm{% endblock %}
+{% block LD %}armlink{% endblock %}
+{% block AR %}armar{% endblock %}
+{% block CPP %}armclang{% endblock %}
+{% block OBJCOPY %}fromelf{% endblock %}
+
+{% block TOBIN %}--bin{% endblock %}
+{% block TOHEX %}--i32{% endblock %}
+{% block objcopy_output %}--output{% endblock %}
+
+{% block TARGET_EXE_EXT %}.axf{% endblock %}
+
+{% block COMMON_FLAGS %} --cpu $(CPU) --$(INSTRUCTION_MODE){% endblock %}
+{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
+{% block CPP_FLAGS %}-E{% endblock %}
+{% block ASM_SYMBOLS %} --cpreproc --cpreproc_opts=-D"{{macros|join("\",-D\"")}}"{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -27,7 +27,7 @@
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
 # Add -Wa,armasm,--show_cmdline to ASFLAGS for armclang to display the armasm command
-{% block ASFLAGS %}-masm=auto -x assembler-with-cpp $(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
+{% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter=$(LD_SCRIPT) --map --list $(OBJ_FOLDER)$(TARGET).map{% endblock %}
 {% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=cortex-m4 -MMD{% endblock %}
 {% block ASM_SYMBOLS %}${CC_SYMBOLS}{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -8,8 +8,8 @@
 {% block CPP %}armclang{% endblock %}
 {% block OBJCOPY %}fromelf{% endblock %}
 
-{% block TOBIN %}--bin{% endblock %}
-{% block TOHEX %}--i32{% endblock %}
+{% block TOBIN %}--bincombined{% endblock %}
+{% block TOHEX %}--i32combined{% endblock %}
 {% block objcopy_output %}--output{% endblock %}
 
 {% block TARGET_EXE_EXT %}.axf{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -7,10 +7,15 @@
 {% block AR %}armar{% endblock %}
 {% block CPP %}armclang{% endblock %}
 {% block OBJCOPY %}fromelf{% endblock %}
+{% block SIZE %}fromelf{% endblock %}
+{% block NM %}fromelf{% endblock %}
 
 {% block TOBIN %}--bincombined{% endblock %}
 {% block TOHEX %}--i32combined{% endblock %}
 {% block objcopy_output %}--output{% endblock %}
+{% block SIZEFLAGS %}--text -z{% endblock %}
+{% block nm_output %}--output{% endblock %}
+{% block NMFLAGS %}--text -arz{% endblock %}
 
 {% block TARGET_EXE_EXT %}.axf{% endblock %}
 
@@ -18,7 +23,6 @@
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
 {% block ASFLAGS %}$(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
-{% block NMFLAGS %}-n -f posix -C -l{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
 {% block LD_CPP_FLAGS %}-E -xc{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -7,12 +7,16 @@
 {% block AR %}armar{% endblock %}
 {% block CPP %}armclang{% endblock %}
 {% block OBJCOPY %}fromelf{% endblock %}
+{% block OBJDUMP %}fromelf{% endblock %}
 {% block SIZE %}fromelf{% endblock %}
 {% block NM %}fromelf{% endblock %}
 
 {% block TOBIN %}--bincombined{% endblock %}
 {% block TOHEX %}--i32combined{% endblock %}
 {% block objcopy_output %}--output{% endblock %}
+{% block objdump_output %}--output{% endblock %}
+{% block OBJDUMPFLAGS %}--text -acdyrz --interleave=source{% endblock %}
+{% block GENASMFLAGS %}-S -W{% endblock %}
 {% block SIZEFLAGS %}--text -z{% endblock %}
 {% block nm_output %}--output{% endblock %}
 {% block NMFLAGS %}--text -arz{% endblock %}

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -26,9 +26,8 @@
 {% block COMMON_FLAGS %}--target=arm-arm-none-eabi -mcpu=$(CPU) -m$(INSTRUCTION_MODE){% endblock %}
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
+# Add -Wa,armasm,--show_cmdline to debug calls to armasm through armclang
 {% block ASFLAGS %}-masm=auto -x assembler-with-cpp $(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
 {% block LD_OPTIONS %}--strict --scatter=$(LD_SCRIPT) --map --list $(OBJ_FOLDER)$(TARGET).map{% endblock %}
-{% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=star{% endblock %}
+{% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=star -MMD{% endblock %}
 {% block ASM_SYMBOLS %}${CC_SYMBOLS}{% endblock %}
-
-

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -27,7 +27,7 @@
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
 {% block ASFLAGS %}-masm=auto -x assembler-with-cpp $(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
-{% block LD_OPTIONS %}--strict --scatter=$(LD_SCRIPT){% endblock %}
+{% block LD_OPTIONS %}--strict --scatter=$(LD_SCRIPT) --map --list $(OBJ_FOLDER)$(TARGET).map{% endblock %}
 {% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=star{% endblock %}
 {% block ASM_SYMBOLS %}${CC_SYMBOLS}{% endblock %}
 

--- a/project_generator/templates/makefile_armclang.tmpl
+++ b/project_generator/templates/makefile_armclang.tmpl
@@ -26,33 +26,9 @@
 {% block COMMON_FLAGS %}--target=arm-arm-none-eabi -mcpu=$(CPU) -m$(INSTRUCTION_MODE){% endblock %}
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD{% endblock %}
-{% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
-{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) $(patsubst %,--predefine "%",$(CC_SYMBOLS) $(INC_DIRS_F)){% endblock %}
+{% block ASFLAGS %}-masm=auto -x assembler-with-cpp $(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
+{% block LD_OPTIONS %}--strict --scatter=$(LD_SCRIPT){% endblock %}
 {% block CPP_FLAGS %}-E -xc --target=arm-arm-none-eabi -mcpu=star{% endblock %}
-{% block ASM_SYMBOLS %} -D"{{macros|join("\" -D\"")}}"{% endblock %}
+{% block ASM_SYMBOLS %}${CC_SYMBOLS}{% endblock %}
 
-{% block RECIPES %}
-# Compile C sources.
-$(OBJ_FOLDER)%.o : %.c
-	@$(call printmessage,c,Compiling, $<)
-	$(at)$(CC) $(CFLAGS) $< -S -w -o $(@:%.o=%.S)
-	$(at)$(CC) $(CFLAGS) $< -o $@
-#	$(at)fromelf --text -acdyrz --interleave=source $@ > $(@:%.o=%.lst)
 
-# Compile C++ sources.
-$(OBJ_FOLDER)%.o : %.cpp
-	@$(call printmessage,cxx,Compiling, $<)
-	$(at)$(CXX) $(CXXFLAGS) $< -S -w -o $(@:%.o=%.S)
-	$(at)$(CXX) $(CXXFLAGS) $< -o $@
-#	$(at)fromelf -cdyrz --interleave=source $@ > $(@:%.o=%.lst)
-
-# Preprocess and assemble .S sources.
-$(OBJ_FOLDER)%.o : %.S
-	@$(call printmessage,asm,Assembling, $<)
-	$(at)$(AS) $(ASFLAGS) $< -o $@
-
-# Assemble .s sources.
-$(OBJ_FOLDER)%.o : %.s
-	@$(call printmessage,asm,Assembling, $<)
-	$(at)$(AS) $(ASFLAGS) $< -o $@
-{% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -14,6 +14,10 @@
 {% block TARGET_EXE_EXT %}.elf{% endblock %}
 
 {% block COMMON_FLAGS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -MMD -MP $(CC_SYMBOLS) {% endblock %}
+{% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
+{% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
+{% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
+{% block NMFLAGS %}-n -f posix -C -l{% endblock %}
 {% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT) {% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
 {% block LD_CPP_FLAGS %}-x c -P{% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -7,9 +7,14 @@
 {% block AR %}ar{% endblock %}
 {% block CPP %}cpp{% endblock %}
 {% block OBJCOPY %}objcopy{% endblock %}
+{% block SIZE %}size{% endblock %}
+{% block NM %}nm{% endblock %}
 
 {% block TOHEX %}-O ihex{% endblock %}
 {% block TOBIN %}-O binary{% endblock %}
+{% block SIZEFLAGS %}--totals{% endblock %}
+{% block nm_output %}>{% endblock %}
+{% block NMFLAGS %}-n -f posix -C -l{% endblock %}
 
 {% block TARGET_EXE_EXT %}.elf{% endblock %}
 
@@ -17,7 +22,6 @@
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
 {% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
-{% block NMFLAGS %}-n -f posix -C -l{% endblock %}
 {% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT) {% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
 {% block LD_CPP_FLAGS %}-x c -P{% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -22,11 +22,10 @@
 
 {% block TARGET_EXE_EXT %}.elf{% endblock %}
 
-{% block CPP_FLAGS %}-E{% endblock %}
 {% block COMMON_FLAGS %}-mcpu=$(CPU) -m$(INSTRUCTION_MODE){% endblock %}
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD -MP{% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD -MP{% endblock %}
 {% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
 {% block LD_OPTIONS %}$(COMMON_FLAGS) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT){% endblock %}
-{% block LD_CPP_FLAGS %}-x c -P{% endblock %}
+{% block CPP_FLAGS %}-E -x c -P -MMD{% endblock %}
 {% block ASM_SYMBOLS %}$(CC_SYMBOLS){% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -7,11 +7,15 @@
 {% block AR %}ar{% endblock %}
 {% block CPP %}cpp{% endblock %}
 {% block OBJCOPY %}objcopy{% endblock %}
+{% block OBJDUMP %}objdump{% endblock %}
 {% block SIZE %}size{% endblock %}
 {% block NM %}nm{% endblock %}
 
 {% block TOHEX %}-O ihex{% endblock %}
 {% block TOBIN %}-O binary{% endblock %}
+{% block objdump_output %}>{% endblock %}
+{% block OBJDUMPFLAGS %}-x --disassemble -S{% endblock %}
+{% block GENASMFLAGS %}-S -w{% endblock %}
 {% block SIZEFLAGS %}--totals{% endblock %}
 {% block nm_output %}>{% endblock %}
 {% block NMFLAGS %}-n -f posix -C -l{% endblock %}

--- a/project_generator/templates/makefile_gcc.tmpl
+++ b/project_generator/templates/makefile_gcc.tmpl
@@ -22,11 +22,11 @@
 
 {% block TARGET_EXE_EXT %}.elf{% endblock %}
 
-{% block COMMON_FLAGS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -MMD -MP $(CC_SYMBOLS) {% endblock %}
-{% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
-{% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) -c $(CC_SYMBOLS){% endblock %}
-{% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) -c $(ASM_SYMBOLS){% endblock %}
-{% block LD_OPTIONS %} -mcpu=$(CPU) -m$(INSTRUCTION_MODE) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT) {% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
+{% block COMMON_FLAGS %}-mcpu=$(CPU) -m$(INSTRUCTION_MODE){% endblock %}
+{% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD -MP{% endblock %}
+{% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c -MMD -MP{% endblock %}
+{% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS) -c{% endblock %}
+{% block LD_OPTIONS %}$(COMMON_FLAGS) -Wl,-Map=$(OBJ_FOLDER)$(TARGET).map,--cref -T$(LD_SCRIPT){% endblock %}
 {% block LD_CPP_FLAGS %}-x c -P{% endblock %}
 {% block ASM_SYMBOLS %}$(CC_SYMBOLS){% endblock %}

--- a/project_generator/tools/gccarm.py
+++ b/project_generator/tools/gccarm.py
@@ -22,7 +22,7 @@ logger = logging.getLogger('progen.tools.gccarm')
 class MakefileGccArm(MakefileTool):
 
     def __init__(self, workspace, env_settings):
-        MakefileTool.__init__(self, workspace, env_settings, logging)
+        MakefileTool.__init__(self, workspace, env_settings, logger)
         # enable preprocessing linker files for GCC ARM
         self.workspace['preprocess_linker_file'] = True
         self.workspace['linker_extension'] = '.ld'
@@ -39,7 +39,9 @@ class MakefileGccArm(MakefileTool):
         """ Processes misc options specific for GCC ARM, and run generator """
         generated_projects = deepcopy(self.generated_projects)
         self.process_data_for_makefile(self.workspace)
-        generated_projects['path'], generated_projects['files']['makefile'] = self.gen_file_jinja('makefile_gcc.tmpl', self.workspace, 'Makefile', self.workspace['output_dir']['path'])
+        generated_projects['path'], generated_projects['files']['makefile'] = \
+            self.gen_file_jinja('makefile_gcc.tmpl', self.workspace, 'Makefile',
+                                self.workspace['output_dir']['path'])
         return generated_projects
 
     def process_data_for_makefile(self, project_data):

--- a/project_generator/tools/makearmcc.py
+++ b/project_generator/tools/makearmcc.py
@@ -33,8 +33,10 @@ class MakefileArmcc(MakefileTool):
         return 'armcc'
 
     def export_project(self):
-        """ Processes misc options specific for GCC ARM, and run generator """
+        """ Processes misc options specific for ARMCC, and run generator """
         generated_projects = deepcopy(self.generated_projects)
         self.process_data_for_makefile(self.workspace)
-        generated_projects['path'], generated_projects['files']['makefile'] = self.gen_file_jinja('makefile_armcc.tmpl', self.workspace, 'Makefile', self.workspace['output_dir']['path'])
+        generated_projects['path'], generated_projects['files']['makefile'] = \
+            self.gen_file_jinja('makefile_armcc.tmpl', self.workspace, 'Makefile',
+                                self.workspace['output_dir']['path'])
         return generated_projects

--- a/project_generator/tools/makearmclang.py
+++ b/project_generator/tools/makearmclang.py
@@ -23,6 +23,9 @@ class MakefileArmclang(MakefileTool):
 
     def __init__(self, workspace, env_settings):
         MakefileTool.__init__(self, workspace, env_settings, logger)
+        # enable preprocessing linker files for GCC ARM
+        self.workspace['preprocess_linker_file'] = True
+        self.workspace['linker_extension'] = '.sct'
 
     @staticmethod
     def get_toolnames():

--- a/project_generator/tools/makearmclang.py
+++ b/project_generator/tools/makearmclang.py
@@ -23,7 +23,7 @@ class MakefileArmclang(MakefileTool):
 
     def __init__(self, workspace, env_settings):
         MakefileTool.__init__(self, workspace, env_settings, logger)
-        # enable preprocessing linker files for GCC ARM
+        # enable preprocessing linker files for AC6
         self.workspace['preprocess_linker_file'] = True
         self.workspace['linker_extension'] = '.sct'
 
@@ -40,6 +40,6 @@ class MakefileArmclang(MakefileTool):
         generated_projects = deepcopy(self.generated_projects)
         self.process_data_for_makefile(self.workspace)
         generated_projects['path'], generated_projects['files']['makefile'] = \
-                self.gen_file_jinja('makefile_armclang.tmpl', self.workspace, 'Makefile',
-                        self.workspace['output_dir']['path'])
+            self.gen_file_jinja('makefile_armclang.tmpl', self.workspace, 'Makefile',
+                                self.workspace['output_dir']['path'])
         return generated_projects

--- a/project_generator/tools/makearmclang.py
+++ b/project_generator/tools/makearmclang.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Chris Reed
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from copy import deepcopy
+import logging
+
+from .makefile import MakefileTool
+
+logger = logging.getLogger('progen.tools.armclang')
+
+class MakefileArmclang(MakefileTool):
+
+    def __init__(self, workspace, env_settings):
+        MakefileTool.__init__(self, workspace, env_settings, logger)
+
+    @staticmethod
+    def get_toolnames():
+        return ['make_armclang']
+
+    @staticmethod
+    def get_toolchain():
+        return 'armclang'
+
+    def export_project(self):
+        """ Processes misc options specific for AC6, and run generator """
+        generated_projects = deepcopy(self.generated_projects)
+        self.process_data_for_makefile(self.workspace)
+        generated_projects['path'], generated_projects['files']['makefile'] = \
+                self.gen_file_jinja('makefile_armclang.tmpl', self.workspace, 'Makefile',
+                        self.workspace['output_dir']['path'])
+        return generated_projects

--- a/project_generator/tools/makefile.py
+++ b/project_generator/tools/makefile.py
@@ -126,6 +126,8 @@ class MakefileTool(Tool, Exporter):
             args += ['-j', str(kwargs['jobs'])]
         except KeyError:
             pass
+        if 'verbose' in kwargs:
+            args += ["VERBOSE=%d" % (1 if kwargs['verbose'] else 0)]
         args += ['all']
         self.logging.debug(args)
 

--- a/project_generator/tools/makefile.py
+++ b/project_generator/tools/makefile.py
@@ -50,7 +50,6 @@ class MakefileTool(Tool, Exporter):
         self.env_settings = env_settings
         self.logging = logging
 
-
     def _parse_specific_options(self, data):
         """ Parse all specific setttings. """
         data['common_flags'] = []
@@ -98,7 +97,6 @@ class MakefileTool(Tool, Exporter):
         self._get_libs(project_data)
         self._parse_specific_options(project_data)
 
-
         pro_def = ProGenDef()
 
         if pro_def.get_mcu_core(project_data['target'].lower()):
@@ -119,7 +117,7 @@ class MakefileTool(Tool, Exporter):
         # cwd: relpath(join(project_path, ("gcc_arm" + project)))
         # > make all
         path = dirname(self.workspace['files']['makefile'])
-        self.logging.debug("Building GCC ARM project: %s" % path)
+        self.logging.debug("Building make project: %s" % path)
 
         args = ['make']
         try:

--- a/project_generator/tools_supported.py
+++ b/project_generator/tools_supported.py
@@ -1,4 +1,5 @@
 # Copyright 2014-2015 0xc0170
+# Copyright (c) 2020 Chris Reed
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +19,7 @@ from .tools.coide import Coide
 from .tools.eclipse import EclipseGnuARM
 from .tools.gccarm import MakefileGccArm
 from .tools.makearmcc import MakefileArmcc
+from .tools.makearmclang import MakefileArmclang
 from .tools.sublimetext import SublimeTextMakeGccARM
 from .tools.gdb import GDB, ARMNoneEABIGDB, JLinkGDB
 from .tools.cmake import CMakeGccArm
@@ -50,7 +52,8 @@ class ToolsSupported:
         'uvision5':             Uvision5,
         'coide':                Coide,
         'make_gcc_arm':         MakefileGccArm,
-        'make_armcc':           MakefileArmcc,
+        'make_armcc':           MakefileArmcc, 
+        'make_armclang':        MakefileArmclang,
         'eclipse_make_gcc_arm': EclipseGnuARM,
         'sublime_make_gcc_arm': SublimeTextMakeGccARM,
         'gdb':                  GDB,

--- a/project_generator/tools_supported.py
+++ b/project_generator/tools_supported.py
@@ -34,6 +34,8 @@ class ToolsSupported:
         'iar':           'iar_arm',
         'make_gcc':      'make_gcc_arm',
         'gcc_arm':       'make_gcc_arm',
+        'armcc':         'make_armcc',
+        'armclang':      'make_armclang',
         'eclipse':       'eclipse_make_gcc_arm',
         'sublime':       'sublime_make_gcc_arm',
         'sublime_text':  'sublime_make_gcc_arm',


### PR DESCRIPTION
This is based on the initial work by @flit and it works on [a fork of DAPLink](https://github.com/mathias-arm/DAPLink/tree/archive/armclang) that adds support for `make_gcc` and `make_armclang`. A test with `ARM Compiler 5.06 update 6`, `ARM Compiler 6.14.1` and `GNU Tools for Arm Embedded Processors 9-2019-q4-major`, built successfully all 143 images for each compiler.

There are some changes to make_gcc and make_armcc to make them consistent.