### PR TITLE
Add support for CMake for GCC / ARMCC / ARMCLANG

### DIFF
--- a/project_generator/commands/__init__.py
+++ b/project_generator/commands/__init__.py
@@ -26,3 +26,12 @@ def argparse_string_type(case_converter, prefer_hyphen=False):
         return lambda string: case_converter(string).replace("_","-")
     else:
         return lambda string: case_converter(string).replace("-","_")
+
+def split_options(opts):
+    options = {}
+    if opts is None:
+        return options
+    for o in opts:
+        r = o.split('=', 1)
+        options[r[0]] = None if len(r) == 1 else r[1]
+    return options

--- a/project_generator/commands/build.py
+++ b/project_generator/commands/build.py
@@ -23,22 +23,24 @@ help = 'Build a project'
 
 def run(args):
     # Export if we know how, otherwise return
+    combined_projects = args.projects + args.project or ['']
+    kwargs = split_options(args.options)
     generator = Generator(args.file)
     any_build_failed = False
     any_export_failed = False
-    for project in generator.generate(args.project):
-        clean_failed = False
-        if args.clean and project.clean(args.tool) == -1:
-            clean_failed = True # So we don't attempt to generate or build this project.
-            any_build_failed = True
-        if not clean_failed:
-            if project.generate(args.tool, args.copy) == -1:
-                any_export_failed = True
-            kwargs = split_options(args.options)
-            if project.build(args.tool, jobs=args.jobs, **kwargs) == -1:
+    for project_name in combined_projects:
+        for project in generator.generate(project_name):
+            clean_failed = False
+            if args.clean and project.clean(args.tool) == -1:
+                clean_failed = True # So we don't attempt to generate or build this project.
                 any_build_failed = True
-        if args.stop_on_failure and (any_build_failed or any_export_failed):
-            break
+            if not clean_failed:
+                if project.generate(args.tool, args.copy) == -1:
+                    any_export_failed = True
+                if project.build(args.tool, jobs=args.jobs, **kwargs) == -1:
+                    any_build_failed = True
+            if args.stop_on_failure and (any_build_failed or any_export_failed):
+                break
 
     if any_build_failed or any_export_failed:
         return -1
@@ -54,7 +56,7 @@ def setup(subparser):
         "-f", "--file", help="YAML projects file", default='projects.yaml',
         type=argparse_filestring_type)
     subparser.add_argument(
-        "-p", "--project", help="Name of the project to build", default = '')
+        "-p", "--project", dest="projects", action='append', default=[], help="Name of the project to build")
     subparser.add_argument(
         "-t", "--tool", help="Build a project files for provided tool",
         type=argparse_string_type(str.lower, False), choices=list(ToolsSupported.TOOLS_DICT.keys()) + list(ToolsSupported.TOOLS_ALIAS.keys()))
@@ -69,3 +71,5 @@ def setup(subparser):
     subparser.add_argument(
         "-j", "--jobs", action="store", type=int, default=1,
         help="Number of concurrent build jobs (not supported by all tools)")
+    subparser.add_argument("project", nargs='*',
+                        help="Specify projects to be generated and built")

--- a/project_generator/commands/build.py
+++ b/project_generator/commands/build.py
@@ -17,10 +17,9 @@ import logging
 from ..tools_supported import ToolsSupported
 from ..generate import Generator
 from ..settings import ProjectSettings
-from . import argparse_filestring_type, argparse_string_type
+from . import argparse_filestring_type, argparse_string_type, split_options
 
 help = 'Build a project'
-
 
 def run(args):
     # Export if we know how, otherwise return
@@ -35,7 +34,8 @@ def run(args):
         if not clean_failed:
             if project.generate(args.tool, args.copy) == -1:
                 any_export_failed = True
-            if project.build(args.tool, jobs=args.jobs) == -1:
+            kwargs = split_options(args.options)
+            if project.build(args.tool, jobs=args.jobs, **kwargs) == -1:
                 any_build_failed = True
         if args.stop_on_failure and (any_build_failed or any_export_failed):
             break
@@ -62,6 +62,8 @@ def setup(subparser):
         "-c", "--copy", action="store_true", help="Copy all files to the exported directory")
     subparser.add_argument(
         "-k", "--clean", action="store_true", help="Clean project before building")
+    subparser.add_argument(
+        "-o", "--options", action="append", help="Toolchain options")
     subparser.add_argument(
         "-x", "--stop-on-failure", action="store_true", help="Stop on first failure")
     subparser.add_argument(

--- a/project_generator/commands/clean.py
+++ b/project_generator/commands/clean.py
@@ -22,9 +22,11 @@ help = 'Clean generated projects'
 
 
 def run(args):
+    combined_projects = args.projects + args.project or ['']
     generator = Generator(args.file)
-    for project in generator.generate(args.project):
-        project.clean(args.tool)
+    for project_name in (combined_projects):
+        for project in generator.generate(project_name):
+            project.clean(args.tool)
     return 0
 
 def setup(subparser):
@@ -33,7 +35,10 @@ def setup(subparser):
     subparser.add_argument('-q', dest='quietness', action='count', default=0,
                         help='Decrease the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument("-f", "--file", help="YAML projects file", default='projects.yaml', type=argparse_filestring_type)
-    subparser.add_argument("-p", "--project", required = True, help="Specify which project to be removed")
+    subparser.add_argument("-p", "--project", dest="projects", action='append', default=[],
+                        help="Specify which project to be removed")
     subparser.add_argument(
-        "-t", "--tool", help="Clean project files for this tool",
+        "-t", "--tool", help="Clean project files for this tool", required=True,
         type=argparse_string_type(str.lower, False), choices=list(ToolsSupported.TOOLS_DICT.keys()) + list(ToolsSupported.TOOLS_ALIAS.keys()))
+    subparser.add_argument("project", nargs='*',
+                        help="Specify projects to be removed")

--- a/project_generator/commands/generate.py
+++ b/project_generator/commands/generate.py
@@ -17,7 +17,7 @@ import multiprocessing as mp
 
 from ..tools_supported import ToolsSupported
 from ..generate import Generator
-from . import argparse_filestring_type, argparse_string_type
+from . import argparse_filestring_type, argparse_string_type, split_options
 
 logger = logging.getLogger('progen.generate')
 
@@ -42,7 +42,8 @@ def _generate_project(project, args):
     if project.generate(args.tool, copied=args.copy, copy=args.copy) == -1:
         export_failed = True
     if args.build:
-        if project.build(args.tool) == -1:
+        kwargs = split_options(args.options)
+        if project.build(args.tool, **kwargs) == -1:
             build_failed = True
     return (build_failed, export_failed)
 
@@ -102,6 +103,8 @@ def setup(subparser):
         "-b", "--build", action="store_true", help="Build defined projects")
     subparser.add_argument(
         "-c", "--copy", action="store_true", help="Copy all files to the exported directory")
+    subparser.add_argument(
+        "-o", "--options", action="append", help="Toolchain options")
     num_cpus = _get_default_jobs()
     subparser.add_argument(
         "-j", "--jobs", action="store", type=int, default=num_cpus,

--- a/project_generator/templates/cmakelist_armcc.tmpl
+++ b/project_generator/templates/cmakelist_armcc.tmpl
@@ -21,31 +21,6 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.6)
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_ARCH arm-arm-none-eabi)
 
-{% if 0 %}
-################## Ignore this section ##################
-# This section works around some of the problems of armclang
-# support in CMake (some of them are mentioned in this ticket
-# https://gitlab.kitware.com/cmake/cmake/-/issues/21173)
-
-# Disable default of CMAKE_SYSTEM_PROCESSOR mandatory
-set(__march_flag_set True FORCE)
-set(__mcpu_flag_set True FORCE)
-
-# Do not try to check that the compiler works
-set(CMAKE_C_COMPILER_WORKS True)
-set(CMAKE_CXX_COMPILER_WORKS True)
-set(CMAKE_ASM_COMPILER_WORKS True)
-
-set(CMAKE_C_COMPILER_FORCED True)
-set(CMAKE_CXX_COMPILER_FORCED True)
-set(CMAKE_ASM_COMPILER_FORCED True)
-
-# Do not try to compile for the host
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-
-################## /Ignore this section ##################
-{% endif %}
-
 set(CMAKE_C_COMPILER armcc)
 set(CMAKE_CXX_COMPILER armcc)
 set(CMAKE_ASM_COMPILER armasm)
@@ -95,13 +70,6 @@ target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
     {{library}}{% endfor %}{% if misc['standard_libraries'] %}{% for library in misc['standard_libraries'] %}
     {{library}}{% endfor %}{% endif %})
 
-# target_link_options({{name}} PRIVATE
-#     --cpu={{core}}{% for flag in misc['ld_flags'] %}
-#     "{{flag}}"{% endfor %}{% for path in include_paths %}
-#     --predefine=-I{{path}}{% endfor %}{% for symbol in macros %}
-#     --predefine=-D{{symbol}}{% endfor %}
-#     --strict --scatter={{linker_file}}
-#     --map --list ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.map)
 target_link_options({{name}} PRIVATE
     --cpu={{core}}{% for flag in misc['ld_flags'] %}
     {{flag}}{% endfor %}

--- a/project_generator/templates/cmakelist_armcc.tmpl
+++ b/project_generator/templates/cmakelist_armcc.tmpl
@@ -1,0 +1,132 @@
+{#
+# Copyright (c) 2020 Mathias Brossard
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+# This project was exported via the project generator.
+# More information https://github.com/project-generator/project_generator
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.6)
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_ARCH arm-arm-none-eabi)
+
+{% if 0 %}
+################## Ignore this section ##################
+# This section works around some of the problems of armclang
+# support in CMake (some of them are mentioned in this ticket
+# https://gitlab.kitware.com/cmake/cmake/-/issues/21173)
+
+# Disable default of CMAKE_SYSTEM_PROCESSOR mandatory
+set(__march_flag_set True FORCE)
+set(__mcpu_flag_set True FORCE)
+
+# Do not try to check that the compiler works
+set(CMAKE_C_COMPILER_WORKS True)
+set(CMAKE_CXX_COMPILER_WORKS True)
+set(CMAKE_ASM_COMPILER_WORKS True)
+
+set(CMAKE_C_COMPILER_FORCED True)
+set(CMAKE_CXX_COMPILER_FORCED True)
+set(CMAKE_ASM_COMPILER_FORCED True)
+
+# Do not try to compile for the host
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+################## /Ignore this section ##################
+{% endif %}
+
+set(CMAKE_C_COMPILER armcc)
+set(CMAKE_CXX_COMPILER armcc)
+set(CMAKE_ASM_COMPILER armasm)
+set(CMAKE_AR armar)
+set(CMAKE_LINKER armlink)
+set(CMAKE_OBJCOPY fromelf)
+set(CMAKE_EXECUTABLE_SUFFIX_C ".axf")
+
+# Start project
+project({{name}} LANGUAGES C CXX ASM)
+
+{% if output_type == 'exe' %}# Add Executable
+add_executable({{name}}){% else %}# Add Library
+add_library({{name}} STATIC){% endif %}
+
+# Set source files
+target_sources({{name}} PUBLIC{% for file in source_files_c %}
+    "{{file}}"{% endfor %}{% for file in source_files_cpp %}
+    "{{file}}"{% endfor %}{% for file in source_files_s %}
+    "{{file}}"{% endfor %}{% for file in source_files_obj %}
+    "{{file}}"{% endfor %})
+
+# Set macros
+target_compile_definitions({{name}} PRIVATE{% for symbol in macros %}
+    {{symbol}}{% endfor %})
+
+# Set include_paths
+target_include_directories({{name}} PRIVATE{% for path in include_paths %}
+    {{path}}{% endfor %})
+
+# Set compilation options
+target_compile_options({{name}} PRIVATE
+    --cpu {{core}} --thumb{% for flag in misc['common_flags'] %}
+    {{flag}}{% endfor %}{% for flag in misc['cxx_flags'] %}
+    $<$<COMPILE_LANGUAGE:Cxx>:{{flag}}>{% endfor %}{% for flag in misc['c_flags'] %}
+    $<$<COMPILE_LANGUAGE:C>:{{flag}}>{% endfor %}{% for flag in misc['asm_flags'] %}
+    $<$<COMPILE_LANGUAGE:ASM>:{{flag}}>{% endfor %}
+    $<$<COMPILE_LANGUAGE:ASM>:--cpreproc>{% for symbol in macros %}
+    $<$<COMPILE_LANGUAGE:ASM>:--cpreproc_opts=-D{{symbol}}>{% endfor %})
+
+set_target_properties({{name}} PROPERTIES LINKER_LANGUAGE C)
+
+target_link_directories({{name}} PRIVATE{% for path in lib_paths %}
+    -L'{{path}}{% endfor %})
+
+target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
+    {{library}}{% endfor %}{% if misc['standard_libraries'] %}{% for library in misc['standard_libraries'] %}
+    {{library}}{% endfor %}{% endif %})
+
+# target_link_options({{name}} PRIVATE
+#     --cpu={{core}}{% for flag in misc['ld_flags'] %}
+#     "{{flag}}"{% endfor %}{% for path in include_paths %}
+#     --predefine=-I{{path}}{% endfor %}{% for symbol in macros %}
+#     --predefine=-D{{symbol}}{% endfor %}
+#     --strict --scatter={{linker_file}}
+#     --map --list ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.map)
+target_link_options({{name}} PRIVATE
+    --cpu={{core}}{% for flag in misc['ld_flags'] %}
+    {{flag}}{% endfor %}
+    --map --list ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.map
+    --predefine=-D$<JOIN:$<TARGET_PROPERTY:COMPILE_DEFINITIONS>, --predefine=-D>
+    --predefine=-I$<JOIN:$<TARGET_PROPERTY:INCLUDE_DIRECTORIES>, --predefine=-I>
+    --strict --scatter={{linker_file}})
+
+# Create bin and hex
+add_custom_target({{name}}_bin SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --bin $<TARGET_FILE:{{name}}> --output ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
+add_custom_target({{name}}_hex SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --i32 $<TARGET_FILE:{{name}}> --output ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
+add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_elf
+    DEPENDS {{name}}_hex)
+
+{% if pre_build_script %}
+add_custom_command(TARGET {{name}} PRE_BUILD {{name}} {% for command in pre_build_script %}
+        COMMAND ../../../{{command}}{% endfor %}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+{% endif %}
+{% if post_build_script %}
+add_custom_command(TARGET {{name}}_binaries POST_BUILD {% for command in post_build_script %}
+        COMMAND ../../../{{command}}{% endfor %}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+{% endif %}

--- a/project_generator/templates/cmakelist_armcc.tmpl
+++ b/project_generator/templates/cmakelist_armcc.tmpl
@@ -122,11 +122,11 @@ add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_
 
 {% if pre_build_script %}
 add_custom_command(TARGET {{name}} PRE_BUILD {{name}} {% for command in pre_build_script %}
-        COMMAND ../../../{{command}}{% endfor %}
+        COMMAND {{command}}{% endfor %}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 {% endif %}
 {% if post_build_script %}
 add_custom_command(TARGET {{name}}_binaries POST_BUILD {% for command in post_build_script %}
-        COMMAND ../../../{{command}}{% endfor %}
+        COMMAND {{command}}{% endfor %}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 {% endif %}

--- a/project_generator/templates/cmakelist_armcc.tmpl
+++ b/project_generator/templates/cmakelist_armcc.tmpl
@@ -48,11 +48,11 @@ target_sources({{name}} PUBLIC{% for file in source_files_c %}
 
 # Set macros
 target_compile_definitions({{name}} PRIVATE{% for symbol in macros %}
-    {{symbol}}{% endfor %})
+    "{{symbol | replace ('"', '\\"') }}"{% endfor %})
 
 # Set include_paths
 target_include_directories({{name}} PRIVATE{% for path in include_paths %}
-    {{path}}{% endfor %})
+    "{{path}}"{% endfor %})
 
 # Set compilation options
 target_compile_options({{name}} PRIVATE
@@ -67,27 +67,27 @@ target_compile_options({{name}} PRIVATE
 set_target_properties({{name}} PROPERTIES LINKER_LANGUAGE C)
 
 target_link_directories({{name}} PRIVATE{% for path in lib_paths %}
-    -L'{{path}}{% endfor %})
+    "{{path}}"{% endfor %})
 
 target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
-    {{library}}{% endfor %}{% if misc['standard_libraries'] %}{% for library in misc['standard_libraries'] %}
-    {{library}}{% endfor %}{% endif %})
+    "{{library}}"{% endfor %}{% if misc['standard_libraries'] %}{% for library in misc['standard_libraries'] %}
+    "{{library}}"{% endfor %}{% endif %})
 
 target_link_options({{name}} PRIVATE
     --cpu={{core}}{% for flag in misc['ld_flags'] %}
     {{flag}}{% endfor %}
-    --map --list ${OUTPUT_DIR}/{{name}}.map
+    --map --list "${OUTPUT_DIR}/{{name}}.map"
     --predefine=-D$<JOIN:$<TARGET_PROPERTY:COMPILE_DEFINITIONS>, --predefine=-D>
     --predefine=-I$<JOIN:$<TARGET_PROPERTY:INCLUDE_DIRECTORIES>, --predefine=-I>
-    --strict --scatter={{linker_file}})
+    --strict "--scatter={{linker_file}}")
 
 # Create bin and hex
-add_custom_target({{name}}_bin SOURCES ${OUTPUT_DIR}/{{name}}.bin)
-add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.bin DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} --bin $<TARGET_FILE:{{name}}> --output ${OUTPUT_DIR}/{{name}}.bin)
-add_custom_target({{name}}_hex SOURCES ${OUTPUT_DIR}/{{name}}.hex)
-add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.hex DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} --i32 $<TARGET_FILE:{{name}}> --output ${OUTPUT_DIR}/{{name}}.hex)
+add_custom_target({{name}}_bin SOURCES "${OUTPUT_DIR}/{{name}}.bin")
+add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.bin" DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --bin $<TARGET_FILE:{{name}}> --output "${OUTPUT_DIR}/{{name}}.bin")
+add_custom_target({{name}}_hex SOURCES "${OUTPUT_DIR}/{{name}}.hex")
+add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.hex" DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --i32 $<TARGET_FILE:{{name}}> --output "${OUTPUT_DIR}/{{name}}.hex")
 add_custom_target({{name}}_binaries ALL DEPENDS {{name}} DEPENDS {{name}}_bin DEPENDS {{name}}_hex)
 
 {% if pre_build_script %}

--- a/project_generator/templates/cmakelist_armcc.tmpl
+++ b/project_generator/templates/cmakelist_armcc.tmpl
@@ -36,6 +36,9 @@ project({{name}} LANGUAGES C CXX ASM)
 add_executable({{name}}){% else %}# Add Library
 add_library({{name}} STATIC){% endif %}
 
+set(OUTPUT_DIR "${CMAKE_BINARY_DIR}")
+set(BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
 # Set source files
 target_sources({{name}} PUBLIC{% for file in source_files_c %}
     "{{file}}"{% endfor %}{% for file in source_files_cpp %}
@@ -73,28 +76,27 @@ target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
 target_link_options({{name}} PRIVATE
     --cpu={{core}}{% for flag in misc['ld_flags'] %}
     {{flag}}{% endfor %}
-    --map --list ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.map
+    --map --list ${OUTPUT_DIR}/{{name}}.map
     --predefine=-D$<JOIN:$<TARGET_PROPERTY:COMPILE_DEFINITIONS>, --predefine=-D>
     --predefine=-I$<JOIN:$<TARGET_PROPERTY:INCLUDE_DIRECTORIES>, --predefine=-I>
     --strict --scatter={{linker_file}})
 
 # Create bin and hex
-add_custom_target({{name}}_bin SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} --bin $<TARGET_FILE:{{name}}> --output ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
-add_custom_target({{name}}_hex SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} --i32 $<TARGET_FILE:{{name}}> --output ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
-add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_elf
-    DEPENDS {{name}}_hex)
+add_custom_target({{name}}_bin SOURCES ${OUTPUT_DIR}/{{name}}.bin)
+add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.bin DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --bin $<TARGET_FILE:{{name}}> --output ${OUTPUT_DIR}/{{name}}.bin)
+add_custom_target({{name}}_hex SOURCES ${OUTPUT_DIR}/{{name}}.hex)
+add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.hex DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --i32 $<TARGET_FILE:{{name}}> --output ${OUTPUT_DIR}/{{name}}.hex)
+add_custom_target({{name}}_binaries ALL DEPENDS {{name}} DEPENDS {{name}}_bin DEPENDS {{name}}_hex)
 
 {% if pre_build_script %}
 add_custom_command(TARGET {{name}} PRE_BUILD {{name}} {% for command in pre_build_script %}
         COMMAND {{command}}{% endfor %}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        WORKING_DIRECTORY ${BUILD_DIR})
 {% endif %}
 {% if post_build_script %}
 add_custom_command(TARGET {{name}}_binaries POST_BUILD {% for command in post_build_script %}
         COMMAND {{command}}{% endfor %}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        WORKING_DIRECTORY ${BUILD_DIR})
 {% endif %}

--- a/project_generator/templates/cmakelist_armcc.tmpl
+++ b/project_generator/templates/cmakelist_armcc.tmpl
@@ -82,10 +82,10 @@ target_link_options({{name}} PRIVATE
     --strict "--scatter={{linker_file}}")
 
 # Create bin and hex
-add_custom_target({{name}}_bin SOURCES "${OUTPUT_DIR}/{{name}}.bin")
+add_custom_target({{name}}_bin DEPENDS "${OUTPUT_DIR}/{{name}}.bin")
 add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.bin" DEPENDS {{name}}
         COMMAND ${CMAKE_OBJCOPY} --bin $<TARGET_FILE:{{name}}> --output "${OUTPUT_DIR}/{{name}}.bin")
-add_custom_target({{name}}_hex SOURCES "${OUTPUT_DIR}/{{name}}.hex")
+add_custom_target({{name}}_hex DEPENDS "${OUTPUT_DIR}/{{name}}.hex")
 add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.hex" DEPENDS {{name}}
         COMMAND ${CMAKE_OBJCOPY} --i32 $<TARGET_FILE:{{name}}> --output "${OUTPUT_DIR}/{{name}}.hex")
 add_custom_target({{name}}_binaries ALL DEPENDS {{name}} DEPENDS {{name}}_bin DEPENDS {{name}}_hex)

--- a/project_generator/templates/cmakelist_armclang.tmpl
+++ b/project_generator/templates/cmakelist_armclang.tmpl
@@ -1,0 +1,133 @@
+{#
+# Copyright (c) 2020 Mathias Brossard
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+# This project was exported via the project generator.
+# More information https://github.com/project-generator/project_generator
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.6)
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_ARCH arm-arm-none-eabi)
+
+################## Ignore this section ##################
+# This section works around some of the problems of armclang
+# support in CMake (some of them are mentioned in this ticket
+# https://gitlab.kitware.com/cmake/cmake/-/issues/21173)
+
+# Disable default of CMAKE_SYSTEM_PROCESSOR mandatory
+set(__march_flag_set True FORCE)
+set(__mcpu_flag_set True FORCE)
+
+# Do not try to check that the compiler works
+set(CMAKE_C_COMPILER_WORKS True)
+set(CMAKE_CXX_COMPILER_WORKS True)
+set(CMAKE_ASM_COMPILER_WORKS True)
+
+set(CMAKE_C_COMPILER_FORCED True)
+set(CMAKE_CXX_COMPILER_FORCED True)
+set(CMAKE_ASM_COMPILER_FORCED True)
+
+# Do not try to compile for the host
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+################## /Ignore this section ##################
+
+set(CMAKE_C_COMPILER armclang)
+set(CMAKE_CXX_COMPILER armclang)
+set(CMAKE_ASM_COMPILER armclang)
+set(CMAKE_AR armar)
+set(CMAKE_LINKER armlinker)
+set(CMAKE_OBJCOPY fromelf)
+set(CMAKE_EXECUTABLE_SUFFIX_C ".axf")
+
+# Start project
+project({{name}} LANGUAGES C CXX ASM)
+
+{% if output_type == 'exe' %}# Add Executable
+add_executable({{name}}){% else %}# Add Library
+add_library({{name}} STATIC){% endif %}
+
+# Set source files
+target_sources({{name}} PUBLIC{% for file in source_files_c %}
+    "{{file}}"{% endfor %}{% for file in source_files_cpp %}
+    "{{file}}"{% endfor %}{% for file in source_files_s %}
+    "{{file}}"{% endfor %}{% for file in source_files_obj %}
+    "{{file}}"{% endfor %})
+
+# Set macros
+target_compile_definitions({{name}} PRIVATE{% for symbol in macros %}
+    {{symbol}}{% endfor %})
+
+# Set include_paths
+target_include_directories({{name}} PRIVATE{% for path in include_paths %}
+    {{path}}{% endfor %})
+
+# Set compilation options
+target_compile_options({{name}} PRIVATE
+    --target=arm-arm-none-eabi -mcpu={{core}} -mthumb{% for flag in misc['common_flags'] %}
+    {{flag}}{% endfor %}{% for flag in misc['cxx_flags'] %}
+    $<$<COMPILE_LANGUAGE:Cxx>:{{flag}}>{% endfor %}{% for flag in misc['c_flags'] %}
+    $<$<COMPILE_LANGUAGE:C>:{{flag}}>{% endfor %}{% for flag in misc['asm_flags'] %}
+    $<$<COMPILE_LANGUAGE:ASM>:{{flag}}>{% endfor %})
+
+set_target_properties({{name}} PROPERTIES LINKER_LANGUAGE C)
+
+target_link_directories({{name}} PRIVATE{% for path in lib_paths %}
+    -L'{{path}}{% endfor %})
+
+target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
+    {{library}}{% endfor %}{% if misc['standard_libraries'] %}{% for library in misc['standard_libraries'] %}
+    {{library}}{% endfor %}{% endif %})
+
+target_link_options({{name}} PRIVATE
+    --cpu={{core}}{% for flag in misc['ld_flags'] %}
+    {{flag}}{% endfor %}
+    --strict --map --list ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.map)
+
+{% if preprocess_linker_file %}
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld
+                   MAIN_DEPENDENCY {{linker_file}}
+                   COMMAND ${CMAKE_C_COMPILER} -E -xc --target=arm-arm-none-eabi -mcpu={{core}}
+                   {% for path in include_paths %} -I{{path}}
+                   {% endfor %}{% for symbol in macros %} -D{{symbol}}
+                   {% endfor %}-o ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld {{linker_file}}
+                   VERBATIM)
+add_custom_target({{name}}_linker_script DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld VERBATIM)
+add_dependencies({{name}} {{name}}_linker_script)
+target_link_options({{name}} PRIVATE --scatter=${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld)
+{% else %}
+target_link_options({{name}} PRIVATE "--scatter={{linker_file}}")
+{% endif %}
+
+# Create bin and hex
+add_custom_target({{name}}_bin SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --bincombined $<TARGET_FILE:{{name}}> --output ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
+add_custom_target({{name}}_hex SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --i32combined $<TARGET_FILE:{{name}}> --output ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
+add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_elf
+    DEPENDS {{name}}_hex)
+
+{% if pre_build_script %}
+add_custom_command(TARGET {{name}} PRE_BUILD {{name}} {% for command in pre_build_script %}
+        COMMAND ../../../{{command}}{% endfor %}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+{% endif %}
+{% if post_build_script %}
+add_custom_command(TARGET {{name}}_binaries POST_BUILD {% for command in post_build_script %}
+        COMMAND ../../../{{command}}{% endfor %}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+{% endif %}

--- a/project_generator/templates/cmakelist_armclang.tmpl
+++ b/project_generator/templates/cmakelist_armclang.tmpl
@@ -123,11 +123,11 @@ add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_
 
 {% if pre_build_script %}
 add_custom_command(TARGET {{name}} PRE_BUILD {{name}} {% for command in pre_build_script %}
-        COMMAND ../../../{{command}}{% endfor %}
+        COMMAND {{command}}{% endfor %}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 {% endif %}
 {% if post_build_script %}
 add_custom_command(TARGET {{name}}_binaries POST_BUILD {% for command in post_build_script %}
-        COMMAND ../../../{{command}}{% endfor %}
+        COMMAND {{command}}{% endfor %}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 {% endif %}

--- a/project_generator/templates/cmakelist_armclang.tmpl
+++ b/project_generator/templates/cmakelist_armclang.tmpl
@@ -59,6 +59,9 @@ project({{name}} LANGUAGES C CXX ASM)
 add_executable({{name}}){% else %}# Add Library
 add_library({{name}} STATIC){% endif %}
 
+set(OUTPUT_DIR "${CMAKE_BINARY_DIR}")
+set(BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
 # Set source files
 target_sources({{name}} PUBLIC{% for file in source_files_c %}
     "{{file}}"{% endfor %}{% for file in source_files_cpp %}
@@ -94,40 +97,39 @@ target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
 target_link_options({{name}} PRIVATE
     --cpu={{core}}{% for flag in misc['ld_flags'] %}
     {{flag}}{% endfor %}
-    --strict --map --list ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.map)
+    --strict --map --list ${OUTPUT_DIR}/{{name}}.map)
 
 {% if preprocess_linker_file %}
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld
+add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.ld
                    MAIN_DEPENDENCY {{linker_file}}
                    COMMAND ${CMAKE_C_COMPILER} -E -xc --target=arm-arm-none-eabi -mcpu={{core}}
                    {% for path in include_paths %} -I{{path}}
                    {% endfor %}{% for symbol in macros %} -D{{symbol}}
-                   {% endfor %}-o ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld {{linker_file}}
+                   {% endfor %}-o ${OUTPUT_DIR}/{{name}}.ld {{linker_file}}
                    VERBATIM)
-add_custom_target({{name}}_linker_script DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld VERBATIM)
+add_custom_target({{name}}_linker_script DEPENDS ${OUTPUT_DIR}/{{name}}.sct VERBATIM)
 add_dependencies({{name}} {{name}}_linker_script)
-target_link_options({{name}} PRIVATE --scatter=${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld)
+target_link_options({{name}} PRIVATE --scatter=${OUTPUT_DIR}/{{name}}.sct)
 {% else %}
 target_link_options({{name}} PRIVATE "--scatter={{linker_file}}")
 {% endif %}
 
 # Create bin and hex
-add_custom_target({{name}}_bin SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} --bincombined $<TARGET_FILE:{{name}}> --output ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
+add_custom_target({{name}}_bin SOURCES ${OUTPUT_DIR}/{{name}}.bin)
+add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.bin DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --bincombined $<TARGET_FILE:{{name}}> --output ${OUTPUT_DIR}/{{name}}.bin)
 add_custom_target({{name}}_hex SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} --i32combined $<TARGET_FILE:{{name}}> --output ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
-add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_elf
-    DEPENDS {{name}}_hex)
+add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.hex DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --i32combined $<TARGET_FILE:{{name}}> --output ${OUTPUT_DIR}/{{name}}.hex)
+add_custom_target({{name}}_binaries ALL DEPENDS {{name}} DEPENDS {{name}}_bin DEPENDS {{name}}_hex)
 
 {% if pre_build_script %}
 add_custom_command(TARGET {{name}} PRE_BUILD {{name}} {% for command in pre_build_script %}
         COMMAND {{command}}{% endfor %}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        WORKING_DIRECTORY ${BUILD_DIR})
 {% endif %}
 {% if post_build_script %}
 add_custom_command(TARGET {{name}}_binaries POST_BUILD {% for command in post_build_script %}
         COMMAND {{command}}{% endfor %}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        WORKING_DIRECTORY ${BUILD_DIR})
 {% endif %}

--- a/project_generator/templates/cmakelist_armclang.tmpl
+++ b/project_generator/templates/cmakelist_armclang.tmpl
@@ -71,11 +71,11 @@ target_sources({{name}} PUBLIC{% for file in source_files_c %}
 
 # Set macros
 target_compile_definitions({{name}} PRIVATE{% for symbol in macros %}
-    {{symbol}}{% endfor %})
+    "{{symbol | replace ('"', '\\"') }}"{% endfor %})
 
 # Set include_paths
 target_include_directories({{name}} PRIVATE{% for path in include_paths %}
-    {{path}}{% endfor %})
+    "{{path}}"{% endfor %})
 
 # Set compilation options
 target_compile_options({{name}} PRIVATE
@@ -88,11 +88,11 @@ target_compile_options({{name}} PRIVATE
 set_target_properties({{name}} PROPERTIES LINKER_LANGUAGE C)
 
 target_link_directories({{name}} PRIVATE{% for path in lib_paths %}
-    -L'{{path}}{% endfor %})
+    "{{path}}"{% endfor %})
 
 target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
-    {{library}}{% endfor %}{% if misc['standard_libraries'] %}{% for library in misc['standard_libraries'] %}
-    {{library}}{% endfor %}{% endif %})
+    "{{library}}"{% endfor %}{% if misc['standard_libraries'] %}{% for library in misc['standard_libraries'] %}
+    "{{library}}"{% endfor %}{% endif %})
 
 target_link_options({{name}} PRIVATE
     --cpu={{core}}{% for flag in misc['ld_flags'] %}
@@ -100,27 +100,27 @@ target_link_options({{name}} PRIVATE
     --strict --map --list ${OUTPUT_DIR}/{{name}}.map)
 
 {% if preprocess_linker_file %}
-add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.ld
-                   MAIN_DEPENDENCY {{linker_file}}
+add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.ld"
+                   MAIN_DEPENDENCY "{{linker_file}}"
                    COMMAND ${CMAKE_C_COMPILER} -E -xc --target=arm-arm-none-eabi -mcpu={{core}}
-                   {% for path in include_paths %} -I{{path}}
-                   {% endfor %}{% for symbol in macros %} -D{{symbol}}
-                   {% endfor %}-o ${OUTPUT_DIR}/{{name}}.ld {{linker_file}}
+                   {% for path in include_paths %} "-I{{path}}"
+                   {% endfor %}{% for symbol in macros %} "-D{{symbol | replace ('"', '\\"')}}"
+                   {% endfor %}-o "${OUTPUT_DIR}/{{name}}.sct" "{{linker_file}}"
                    VERBATIM)
-add_custom_target({{name}}_linker_script DEPENDS ${OUTPUT_DIR}/{{name}}.sct VERBATIM)
+add_custom_target({{name}}_linker_script DEPENDS "${OUTPUT_DIR}/{{name}}.sct" VERBATIM)
 add_dependencies({{name}} {{name}}_linker_script)
-target_link_options({{name}} PRIVATE --scatter=${OUTPUT_DIR}/{{name}}.sct)
+target_link_options({{name}} PRIVATE "--scatter=${OUTPUT_DIR}/{{name}}.sct")
 {% else %}
 target_link_options({{name}} PRIVATE "--scatter={{linker_file}}")
 {% endif %}
 
 # Create bin and hex
-add_custom_target({{name}}_bin SOURCES ${OUTPUT_DIR}/{{name}}.bin)
-add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.bin DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} --bincombined $<TARGET_FILE:{{name}}> --output ${OUTPUT_DIR}/{{name}}.bin)
-add_custom_target({{name}}_hex SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
-add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.hex DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} --i32combined $<TARGET_FILE:{{name}}> --output ${OUTPUT_DIR}/{{name}}.hex)
+add_custom_target({{name}}_bin SOURCES "${OUTPUT_DIR}/{{name}}.bin")
+add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.bin" DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --bincombined $<TARGET_FILE:{{name}}> --output "${OUTPUT_DIR}/{{name}}.bin")
+add_custom_target({{name}}_hex SOURCES "${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex")
+add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.hex" DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} --i32combined $<TARGET_FILE:{{name}}> --output "${OUTPUT_DIR}/{{name}}.hex")
 add_custom_target({{name}}_binaries ALL DEPENDS {{name}} DEPENDS {{name}}_bin DEPENDS {{name}}_hex)
 
 {% if pre_build_script %}

--- a/project_generator/templates/cmakelist_armclang.tmpl
+++ b/project_generator/templates/cmakelist_armclang.tmpl
@@ -100,7 +100,7 @@ target_link_options({{name}} PRIVATE
     --strict --map --list ${OUTPUT_DIR}/{{name}}.map)
 
 {% if preprocess_linker_file %}
-add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.ld"
+add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.sct"
                    MAIN_DEPENDENCY "{{linker_file}}"
                    COMMAND ${CMAKE_C_COMPILER} -E -xc --target=arm-arm-none-eabi -mcpu={{core}}
                    {% for path in include_paths %} "-I{{path}}"
@@ -115,10 +115,10 @@ target_link_options({{name}} PRIVATE "--scatter={{linker_file}}")
 {% endif %}
 
 # Create bin and hex
-add_custom_target({{name}}_bin SOURCES "${OUTPUT_DIR}/{{name}}.bin")
+add_custom_target({{name}}_bin DEPENDS "${OUTPUT_DIR}/{{name}}.bin")
 add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.bin" DEPENDS {{name}}
         COMMAND ${CMAKE_OBJCOPY} --bincombined $<TARGET_FILE:{{name}}> --output "${OUTPUT_DIR}/{{name}}.bin")
-add_custom_target({{name}}_hex SOURCES "${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex")
+add_custom_target({{name}}_hex DEPENDS "${OUTPUT_DIR}/{{name}}.hex")
 add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.hex" DEPENDS {{name}}
         COMMAND ${CMAKE_OBJCOPY} --i32combined $<TARGET_FILE:{{name}}> --output "${OUTPUT_DIR}/{{name}}.hex")
 add_custom_target({{name}}_binaries ALL DEPENDS {{name}} DEPENDS {{name}}_bin DEPENDS {{name}}_hex)

--- a/project_generator/templates/cmakelist_gccarm.tmpl
+++ b/project_generator/templates/cmakelist_gccarm.tmpl
@@ -17,7 +17,7 @@
 # This project was exported via the project generator.
 # More information https://github.com/project-generator/project_generator
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.6)
 
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR arm)
@@ -59,7 +59,7 @@ target_compile_options({{name}} PRIVATE
     -mcpu={{core}} -mthumb{% for flag in misc['common_flags'] %}
     {{flag}}{% endfor %}{% for flag in misc['cxx_flags'] %}
     $<$<COMPILE_LANGUAGE:Cxx>:{{flag}}>{% endfor %}{% for flag in misc['c_flags'] %}
-    $<$<COMPILE_LANGUAGE:C>:{{flag}}>{% endfor %}{% for flag in misc['as_flags'] %}
+    $<$<COMPILE_LANGUAGE:C>:{{flag}}>{% endfor %}{% for flag in misc['asm_flags'] %}
     $<$<COMPILE_LANGUAGE:ASM>:{{flag}}>{% endfor %})
 
 set_target_properties({{name}} PROPERTIES LINKER_LANGUAGE C)

--- a/project_generator/templates/cmakelist_gccarm.tmpl
+++ b/project_generator/templates/cmakelist_gccarm.tmpl
@@ -106,12 +106,12 @@ add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_
     DEPENDS {{name}}_hex)
 
 {% if pre_build_script %}
-add_custom_command(TARGET {{name}} PRE_BUILD {{name}} {% for command in pre_build_script %}
-        COMMAND ../../../{{command}}{% endfor %}
+add_custom_command(TARGET {{name}} PRE_BUILD {{name}}{% for command in pre_build_script %}
+        COMMAND {{command}}{% endfor %}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 {% endif %}
 {% if post_build_script %}
-add_custom_command(TARGET {{name}}_binaries POST_BUILD {% for command in post_build_script %}
-        COMMAND ../../../{{command}}{% endfor %}
+add_custom_command(TARGET {{name}}_binaries POST_BUILD{% for command in post_build_script %}
+        COMMAND {{command}}{% endfor %}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 {% endif %}

--- a/project_generator/templates/cmakelist_gccarm.tmpl
+++ b/project_generator/templates/cmakelist_gccarm.tmpl
@@ -39,6 +39,9 @@ project({{name}} LANGUAGES C CXX ASM)
 add_executable({{name}}){% else %}# Add Library
 add_library({{name}} STATIC){% endif %}
 
+set(OUTPUT_DIR "${CMAKE_BINARY_DIR}")
+set(BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
 # Set source files
 target_sources({{name}} PUBLIC{% for file in source_files_c %}
     "{{file}}"{% endfor %}{% for file in source_files_cpp %}
@@ -78,40 +81,41 @@ target_link_options({{name}} PRIVATE
     -mcpu={{core}} -mthumb{% for flag in misc['common_flags'] %}
     {{flag}}{% endfor %}{% for flag in misc['ld_flags'] %}
     {{flag}}{% endfor %}
-    -Wl,-Map=${CMAKE_CURRENT_BINARY_DIR}/{{name}}.map,--cref)
+    -Wl,-Map=${OUTPUT_DIR}/{{name}}.map,--cref)
 
 {% if preprocess_linker_file %}
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld
+add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.ld
                    MAIN_DEPENDENCY {{linker_file}}
                    COMMAND ${CMAKE_C_COMPILER} -E -x c -P -MMD
                    {% for path in include_paths %} -I{{path}}
                    {% endfor %}{% for symbol in macros %} -D{{symbol}}
-                   {% endfor %}-o ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld {{linker_file}}
+                   {% endfor %} -o ${OUTPUT_DIR}/{{name}}.ld {{linker_file}}
                    VERBATIM)
-add_custom_target({{name}}_linker_script DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld VERBATIM)
+add_custom_target({{name}}_linker_script DEPENDS ${OUTPUT_DIR}/{{name}}.ld VERBATIM)
 add_dependencies({{name}} {{name}}_linker_script)
-target_link_options({{name}} PRIVATE -T${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld -static)
+target_link_options({{name}} PRIVATE "-T${OUTPUT_DIR}/{{name}}.ld" -static)
 {% else %}
 target_link_options({{name}} PRIVATE "-T{{linker_file}}" -static)
 {% endif %}
 
 # Create bin and hex
-add_custom_target({{name}}_bin SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:{{name}}> ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
-add_custom_target({{name}}_hex SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:{{name}}> ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
-add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_elf
-    DEPENDS {{name}}_hex)
+add_custom_target({{name}}_bin DEPENDS ${OUTPUT_DIR}/{{name}}.bin)
+add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.bin DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:{{name}}> ${OUTPUT_DIR}/{{name}}.bin)
+add_custom_target({{name}}_hex DEPENDS ${OUTPUT_DIR}/{{name}}.hex)
+add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.hex DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:{{name}}> ${OUTPUT_DIR}/{{name}}.hex)
+add_custom_target({{name}}_binaries ALL DEPENDS {{name}} DEPENDS {{name}}_bin DEPENDS {{name}}_hex)
 
 {% if pre_build_script %}
-add_custom_command(TARGET {{name}} PRE_BUILD {{name}}{% for command in pre_build_script %}
+add_custom_target({{name}}_pre_build {% for command in pre_build_script %}
         COMMAND {{command}}{% endfor %}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        WORKING_DIRECTORY ${BUILD_DIR})
+add_dependencies({{name}} {{name}}_pre_build)
 {% endif %}
+
 {% if post_build_script %}
 add_custom_command(TARGET {{name}}_binaries POST_BUILD{% for command in post_build_script %}
         COMMAND {{command}}{% endfor %}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        WORKING_DIRECTORY ${BUILD_DIR})
 {% endif %}

--- a/project_generator/templates/cmakelist_gccarm.tmpl
+++ b/project_generator/templates/cmakelist_gccarm.tmpl
@@ -51,11 +51,11 @@ target_sources({{name}} PUBLIC{% for file in source_files_c %}
 
 # Set macros
 target_compile_definitions({{name}} PRIVATE{% for symbol in macros %}
-    {{symbol}}{% endfor %})
+    "{{symbol | replace ('"', '\\"') }}"{% endfor %})
 
 # Set include_paths
 target_include_directories({{name}} PRIVATE{% for path in include_paths %}
-    {{path}}{% endfor %})
+    "{{path}}"{% endfor %})
 
 # Set compilation options
 target_compile_options({{name}} PRIVATE
@@ -68,12 +68,12 @@ target_compile_options({{name}} PRIVATE
 set_target_properties({{name}} PROPERTIES LINKER_LANGUAGE C)
 
 target_link_directories({{name}} PRIVATE{% for path in lib_paths %}
-    -L'{{path}}{% endfor %})
+    "{{path}}"{% endfor %})
 
 target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
-    {{library}}{% endfor %}{% if misc['standard_libraries'] %}
+    "{{library}}"{% endfor %}{% if misc['standard_libraries'] %}
     -Wl,--start-group{% for library in misc['standard_libraries'] %}
-    {{library}}{% endfor %}
+    "{{library}}"{% endfor %}
     -Wl,--end-group
     {% endif %})
 
@@ -81,17 +81,17 @@ target_link_options({{name}} PRIVATE
     -mcpu={{core}} -mthumb{% for flag in misc['common_flags'] %}
     {{flag}}{% endfor %}{% for flag in misc['ld_flags'] %}
     {{flag}}{% endfor %}
-    -Wl,-Map=${OUTPUT_DIR}/{{name}}.map,--cref)
+    "-Wl,-Map=${OUTPUT_DIR}/{{name}}.map" -Wl,--cref)
 
 {% if preprocess_linker_file %}
-add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.ld
-                   MAIN_DEPENDENCY {{linker_file}}
+add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.ld"
+                   MAIN_DEPENDENCY "{{linker_file}}"
                    COMMAND ${CMAKE_C_COMPILER} -E -x c -P -MMD
-                   {% for path in include_paths %} -I{{path}}
-                   {% endfor %}{% for symbol in macros %} -D{{symbol}}
-                   {% endfor %} -o ${OUTPUT_DIR}/{{name}}.ld {{linker_file}}
+                   {% for path in include_paths %} "-I{{path}}"
+                   {% endfor %}{% for symbol in macros %} "-D{{symbol | replace ('"', '\\"')}}"
+                   {% endfor %} -o "${OUTPUT_DIR}/{{name}}.ld" "{{linker_file}}"
                    VERBATIM)
-add_custom_target({{name}}_linker_script DEPENDS ${OUTPUT_DIR}/{{name}}.ld VERBATIM)
+add_custom_target({{name}}_linker_script DEPENDS "${OUTPUT_DIR}/{{name}}.ld" VERBATIM)
 add_dependencies({{name}} {{name}}_linker_script)
 target_link_options({{name}} PRIVATE "-T${OUTPUT_DIR}/{{name}}.ld" -static)
 {% else %}
@@ -99,12 +99,12 @@ target_link_options({{name}} PRIVATE "-T{{linker_file}}" -static)
 {% endif %}
 
 # Create bin and hex
-add_custom_target({{name}}_bin DEPENDS ${OUTPUT_DIR}/{{name}}.bin)
-add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.bin DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:{{name}}> ${OUTPUT_DIR}/{{name}}.bin)
-add_custom_target({{name}}_hex DEPENDS ${OUTPUT_DIR}/{{name}}.hex)
-add_custom_command(OUTPUT ${OUTPUT_DIR}/{{name}}.hex DEPENDS {{name}}
-        COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:{{name}}> ${OUTPUT_DIR}/{{name}}.hex)
+add_custom_target({{name}}_bin DEPENDS "${OUTPUT_DIR}/{{name}}.bin")
+add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.bin" DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:{{name}}> "${OUTPUT_DIR}/{{name}}.bin")
+add_custom_target({{name}}_hex DEPENDS "${OUTPUT_DIR}/{{name}}.hex")
+add_custom_command(OUTPUT "${OUTPUT_DIR}/{{name}}.hex" DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:{{name}}> "${OUTPUT_DIR}/{{name}}.hex")
 add_custom_target({{name}}_binaries ALL DEPENDS {{name}} DEPENDS {{name}}_bin DEPENDS {{name}}_hex)
 
 {% if pre_build_script %}

--- a/project_generator/templates/cmakelistgccarm.tmpl
+++ b/project_generator/templates/cmakelistgccarm.tmpl
@@ -100,7 +100,18 @@ add_custom_target({{name}}_bin SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin DEPENDS {{name}}
         COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:{{name}}> ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
 add_custom_target({{name}}_hex SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex DEPENDS {{name}}
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex DEPENDS {{name}}
         COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:{{name}}> ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
 add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_elf
     DEPENDS {{name}}_hex)
+
+{% if pre_build_script %}
+add_custom_command(TARGET {{name}} PRE_BUILD {{name}} {% for command in pre_build_script %}
+        COMMAND ../../../{{command}}{% endfor %}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+{% endif %}
+{% if post_build_script %}
+add_custom_command(TARGET {{name}} POST_BUILD {{name}} {% for command in post_build_script %}
+        COMMAND ../../../{{command}}{% endfor %}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+{% endif %}

--- a/project_generator/templates/cmakelistgccarm.tmpl
+++ b/project_generator/templates/cmakelistgccarm.tmpl
@@ -1,5 +1,6 @@
 {#
 # Copyright (c) 2015 0xc0170
+# Copyright (c) 2020 Mathias Brossard
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,93 +14,92 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #}
-# This project was exported via the project generator.  More information https://github.com/project-generator/project_generator
+# This project was exported via the project generator.
+# More information https://github.com/project-generator/project_generator
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
-
-include(CMakeForceCompiler)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 set(CMAKE_SYSTEM_NAME Generic)
-set(CMAKE_SYSTEM_PROCESSOR {{core}})
+set(CMAKE_SYSTEM_PROCESSOR arm)
 
-find_program(ARM_NONE_EABI_GCC arm-none-eabi-gcc)
-find_program(ARM_NONE_EABI_GPP arm-none-eabi-g++)
-find_program(ARM_NONE_EABI_OBJCOPY arm-none-eabi-objcopy)
-if ((ARM_NONE_EABI_GCC MATCHES ".*-NOTFOUND") OR
-    (ARM_NONE_EABI_GPP MATCHES ".*-NOTFOUND") OR
-    (ARM_NONE_EABI_OBJCOPY MATCHES ".*-NOTFOUND"))
-    MESSAGE(FATAL_ERROR "Could not find the arm-none-eabi gnu toolchain")
-endif()
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(CMAKE_ASM_COMPILER arm-none-eabi-gcc)
+set(CMAKE_LINKER arm-none-eabi-gcc-ld)
+set(CMAKE_AR arm-none-eabi-gcc-ar)
+set(CMAKE_EXECUTABLE_SUFFIX_C ".elf")
 
-cmake_force_c_compiler("${ARM_NONE_EABI_GCC}" GNU)
-cmake_force_cxx_compiler("${ARM_NONE_EABI_GPP}" GNU)
-SET(CMAKE_STATIC_LIBRARY_PREFIX)
-SET(CMAKE_STATIC_LIBRARY_SUFFIX)
+# Do not try to compile for the host
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-SET(CMAKE_EXECUTABLE_LIBRARY_PREFIX)
-SET(CMAKE_EXECUTABLE_LIBRARY_SUFFIX)
+# Start project
+project({{name}} LANGUAGES C CXX ASM)
 
-project ({{name}})
-enable_language(ASM)
+{% if output_type == 'exe' %}# Add Executable
+add_executable({{name}}){% else %}# Add Library
+add_library({{name}} STATIC){% endif %}
+
+# Set source files
+target_sources({{name}} PUBLIC{% for file in source_files_c %}
+    "{{file}}"{% endfor %}{% for file in source_files_cpp %}
+    "{{file}}"{% endfor %}{% for file in source_files_s %}
+    "{{file}}"{% endfor %}{% for file in source_files_obj %} 
+    "{{file}}"{% endfor %})
 
 # Set macros
-{% for symbol in macros %}
-set(DEFINES "${DEFINES} -D{{symbol}}"){% endfor %}
+target_compile_definitions({{name}} PRIVATE{% for symbol in macros %}
+    {{symbol}}{% endfor %})
 
 # Set include_paths
-{% for path in include_paths %}
-include_directories("{{path}}"){% endfor %}
+target_include_directories({{name}} PRIVATE{% for path in include_paths %}
+    {{path}}{% endfor %})
 
-{#
-# TODO 0xc0170: fix this dict
-#{% for library in source_files_lib %}
-#set(LIBRARIES ${LIBRARIES} {{library}}){% endfor %}
-#}
-
-{% for path in lib_paths %}
-link_directories("{{path}}"){% endfor %}
-
-{% for file in source_files_c %}
-set(SOURCES_C ${SOURCES_C} "{{file}}"){% endfor %}
-{% for file in source_files_cpp %}
-set(SOURCES_CPP ${SOURCES_CPP} "{{file}}"){% endfor %}
-{% for file in source_files_s %}
-set(SOURCES_S ${SOURCES_S} "{{file}}"){% endfor %}
-
-{% for file in source_files_obj %}
-set(OBJECT_FILES ${OBJECT_FILES} "{{file}}"){% endfor %}
-
-set(COMMON_FLAGS "-mcpu={{core}} -mthumb {% for flag in misc['common_flags'] %} {{flag}}{% endfor %}")
-set(CMAKE_CXX_FLAGS "${COMMON_FLAGS} ${DEFINES} {% for flag in misc['cxx_flags'] %} {{flag}}{% endfor %}")
-set(CMAKE_C_FLAGS "${COMMON_FLAGS} ${DEFINES} {% for flag in misc['c_flags'] %} {{flag}}{% endfor %}")
-set(CMAKE_EXE_LINKER_FLAGS "-mcpu={{core}} {% for flag in misc['linker_flags'] %} {{flag}}{% endfor %}")
-
-{% if linker_options %}
-set(CMAKE_EXE_LINKER_FLAGS "{{linker_options}}"){% endif %}
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \"-T{{linker_file}}\" -static")
-
-set(EXECUTABLE_OUTPUT_PATH {{build_dir}})
-
-{# Lib or exe #}
-{% if output_type == 'exe' %}
-add_executable({{name}} ${SOURCES_C} ${SOURCES_CPP} ${SOURCES_S}{% if source_files_obj %} ${OBJECT_FILES}{% endif %})
-{% else %}
-add_library({{name}} STATIC ${SOURCES_C} ${SOURCES_CPP} ${SOURCES_S}{% if source_files_obj %} ${OBJECT_FILES}{% endif %})
-{% endif %}
+# Set compilation options
+target_compile_options({{name}} PRIVATE
+    -mcpu={{core}} -mthumb{% for flag in misc['common_flags'] %}
+    {{flag}}{% endfor %}{% for flag in misc['cxx_flags'] %}
+    $<$<COMPILE_LANGUAGE:Cxx>:{{flag}}>{% endfor %}{% for flag in misc['c_flags'] %}
+    $<$<COMPILE_LANGUAGE:C>:{{flag}}>{% endfor %}{% for flag in misc['as_flags'] %}
+    $<$<COMPILE_LANGUAGE:ASM>:{{flag}}>{% endfor %})
 
 set_target_properties({{name}} PROPERTIES LINKER_LANGUAGE C)
 
-# Libraries
-{% if misc['standard_libraries'] %}target_link_libraries({{name}} -Wl,--start-group)
-{% for library in misc['standard_libraries'] %}
-target_link_libraries({{name}} {{library}}){% endfor %}
-target_link_libraries({{name}} -Wl,--end-group)
+target_link_directories({{name}} PRIVATE{% for path in lib_paths %}
+    -L'{{path}}{% endfor %})
+
+target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
+    {{library}}{% endfor %}{% if misc['standard_libraries'] %}
+    -Wl,--start-group{% for library in misc['standard_libraries'] %}
+    {{library}}{% endfor %}
+    -Wl,--end-group
+    {% endif %})
+
+target_link_options({{name}} PRIVATE{% for flag in misc['common_flags'] %}
+    {{flag}}{% endfor %}{% for flag in misc['ld_flags'] %}
+    {{flag}}{% endfor %}
+    -Wl,-Map=${CMAKE_CURRENT_BINARY_DIR}/{{name}}.map,--cref)
+
+{% if preprocess_linker_file %}
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld
+                   MAIN_DEPENDENCY {{linker_file}}
+                   COMMAND ${CMAKE_C_COMPILER} -E -x c -P -MMD
+                   {% for path in include_paths %} -I{{path}}
+                   {% endfor %}{% for symbol in macros %} -D{{symbol}}
+                   {% endfor %}-o ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld {{linker_file}}
+                   VERBATIM)
+add_custom_target({{name}}_linker_script DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld VERBATIM)
+add_dependencies({{name}} {{name}}_linker_script)
+target_link_options({{name}} PRIVATE -T${CMAKE_CURRENT_BINARY_DIR}/{{name}}.ld -static)
+{% else %}
+target_link_options({{name}} PRIVATE "-T{{linker_file}}" -static)
 {% endif %}
 
-# Map file
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker -Map=${CMAKE_CURRENT_SOURCE_DIR}/{{build_dir}}/{{name}}.map")
-
 # Create bin and hex
-add_custom_command(TARGET {{name}} POST_BUILD COMMAND "${ARM_NONE_EABI_OBJCOPY}" -O binary ${CMAKE_CURRENT_SOURCE_DIR}/{{build_dir}}/{{name}} ${CMAKE_CURRENT_SOURCE_DIR}/{{build_dir}}/{{name}}.bin)
-add_custom_command(TARGET {{name}} POST_BUILD COMMAND "${ARM_NONE_EABI_OBJCOPY}" -O ihex ${CMAKE_CURRENT_SOURCE_DIR}/{{build_dir}}/{{name}} ${CMAKE_CURRENT_SOURCE_DIR}/{{build_dir}}/{{name}}.hex)
-
+add_custom_target({{name}}_bin SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:{{name}}> ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.bin)
+add_custom_target({{name}}_hex SOURCES ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex DEPENDS {{name}}
+        COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:{{name}}> ${CMAKE_CURRENT_BINARY_DIR}/{{name}}.hex)
+add_custom_target({{name}}_binaries ALL DEPENDS {{name}}_bin # DEPENDS {{name}}_elf
+    DEPENDS {{name}}_hex)

--- a/project_generator/templates/cmakelistgccarm.tmpl
+++ b/project_generator/templates/cmakelistgccarm.tmpl
@@ -111,7 +111,7 @@ add_custom_command(TARGET {{name}} PRE_BUILD {{name}} {% for command in pre_buil
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 {% endif %}
 {% if post_build_script %}
-add_custom_command(TARGET {{name}} POST_BUILD {{name}} {% for command in post_build_script %}
+add_custom_command(TARGET {{name}}_binaries POST_BUILD {% for command in post_build_script %}
         COMMAND ../../../{{command}}{% endfor %}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 {% endif %}

--- a/project_generator/templates/cmakelistgccarm.tmpl
+++ b/project_generator/templates/cmakelistgccarm.tmpl
@@ -25,6 +25,11 @@ set(CMAKE_SYSTEM_PROCESSOR {{core}})
 find_program(ARM_NONE_EABI_GCC arm-none-eabi-gcc)
 find_program(ARM_NONE_EABI_GPP arm-none-eabi-g++)
 find_program(ARM_NONE_EABI_OBJCOPY arm-none-eabi-objcopy)
+if ((ARM_NONE_EABI_GCC MATCHES ".*-NOTFOUND") OR
+    (ARM_NONE_EABI_GPP MATCHES ".*-NOTFOUND") OR
+    (ARM_NONE_EABI_OBJCOPY MATCHES ".*-NOTFOUND"))
+    MESSAGE(FATAL_ERROR "Could not find the arm-none-eabi gnu toolchain")
+endif()
 
 cmake_force_c_compiler("${ARM_NONE_EABI_GCC}" GNU)
 cmake_force_cxx_compiler("${ARM_NONE_EABI_GPP}" GNU)

--- a/project_generator/templates/cmakelistgccarm.tmpl
+++ b/project_generator/templates/cmakelistgccarm.tmpl
@@ -74,7 +74,8 @@ target_link_libraries({{name}} PRIVATE{% for library in source_files_lib %}
     -Wl,--end-group
     {% endif %})
 
-target_link_options({{name}} PRIVATE{% for flag in misc['common_flags'] %}
+target_link_options({{name}} PRIVATE
+    -mcpu={{core}} -mthumb{% for flag in misc['common_flags'] %}
     {{flag}}{% endfor %}{% for flag in misc['ld_flags'] %}
     {{flag}}{% endfor %}
     -Wl,-Map=${CMAKE_CURRENT_BINARY_DIR}/{{name}}.map,--cref)

--- a/project_generator/templates/cmakelistgccarm.tmpl
+++ b/project_generator/templates/cmakelistgccarm.tmpl
@@ -64,7 +64,7 @@ set(SOURCES_S ${SOURCES_S} "{{file}}"){% endfor %}
 {% for file in source_files_obj %}
 set(OBJECT_FILES ${OBJECT_FILES} "{{file}}"){% endfor %}
 
-set(COMMON_FLAGS "-mcpu={{core}} {% for flag in misc['common_flags'] %} {{flag}}{% endfor %}")
+set(COMMON_FLAGS "-mcpu={{core}} -mthumb {% for flag in misc['common_flags'] %} {{flag}}{% endfor %}")
 set(CMAKE_CXX_FLAGS "${COMMON_FLAGS} ${DEFINES} {% for flag in misc['cxx_flags'] %} {{flag}}{% endfor %}")
 set(CMAKE_C_FLAGS "${COMMON_FLAGS} ${DEFINES} {% for flag in misc['c_flags'] %} {{flag}}{% endfor %}")
 set(CMAKE_EXE_LINKER_FLAGS "-mcpu={{core}} {% for flag in misc['linker_flags'] %} {{flag}}{% endfor %}")

--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -202,7 +202,7 @@ color_ :=
 #  $(call printmessage,cyan,Building, remainder of the message...)
 ifeq ($(OS),Windows_NT)
 define printmessage
-echo "$(7)$(2)$(3)$(5)$(6)"
+echo $(7)$(2)$(3)$(5)$(6)
 endef
 else
 ifeq "$(USE_COLOR)" "1"

--- a/project_generator/tools/cmake.py
+++ b/project_generator/tools/cmake.py
@@ -62,24 +62,21 @@ class CMake(Tool,Exporter):
                     v = value.replace('\\', '/')
                     paths.append(normpath(os.path.join(output_dir, v)))
             data[key] = paths
-        # fix includes
-        includes = []
-        for key in data['include_paths']:
-            if key:
-                k = key.replace('\\', '/')
-                includes.append(normpath(os.path.join(output_dir, k)))
-        data['include_paths'] = includes
+
+        for k in ['include_paths', 'lib_paths']:
+            paths = [path for path in data[k] if path]
+            paths = [normpath(os.path.join(output_dir, path.replace('\\', '/'))) for path in paths]
+            data[k] = paths
+
+        # Those paths are not fixed
+        for k in ['pre_build_script', 'post_build_script']:
+            paths = [path for path in data[k] if path]
+            paths = [normpath(os.path.join(os.getcwd(), path.replace('\\', '/'))) for path in paths]
+            data[k] = paths
 
         if 'linker_file' in data and data['linker_file']:
             lf = data['linker_file'].replace('\\', '/')
             data['linker_file'] = normpath(os.path.join(output_dir, lf))
-
-        lib_paths = []
-        for path in data['lib_paths']:
-            if path:
-                p = path.replace('\\', '/')
-                lib_paths.append(paths.append(normpath(os.path.join(output_dir, p))))
-        data['lib_paths'] = lib_paths
 
     def export_project(self):
         generated_projects = {}

--- a/project_generator/tools/cmake.py
+++ b/project_generator/tools/cmake.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import copy
 import logging
 import subprocess
-from os import getcwd
-from os.path import dirname
 
+from os.path import join, normpath, dirname, exists
 from .tool import Tool, Exporter
 from .gccarm import MakefileGccArm
 from ..util import SOURCE_KEYS
@@ -26,12 +26,13 @@ logger = logging.getLogger('progen.tools.cmake_gcc_arm')
 
 class CMakeGccArm(Tool,Exporter):
 
-    SUCCESSVALUE = 0
     ERRORLEVEL = {
-        0: 'no errors)',
+        0: 'no errors',
         1: 'targets not already up to date',
         2: 'errors'
     }
+
+    SUCCESSVALUE = 0
 
     generated_project = {
         'path': '',
@@ -44,6 +45,9 @@ class CMakeGccArm(Tool,Exporter):
         self.workspace = workspace
         self.exporter = MakefileGccArm(workspace, env_settings)
         self.env_settings = env_settings
+        self.logging = logging
+        self.workspace['preprocess_linker_file'] = True
+
 
     @staticmethod
     def get_toolnames():
@@ -56,21 +60,32 @@ class CMakeGccArm(Tool,Exporter):
     def fix_paths_unix(self, data):
         # cmake seems to require unix paths
         # This might do proper handling in the gcc arm, pass there a param (force normpath to unix)
+        output_dir = os.path.join(os.getcwd(), data['output_dir']['path'].replace('\\', '/'))
         for key in SOURCE_KEYS:
             paths = []
             for value in data[key]:
                 # TODO: this needs to be fixed
-                paths.append(getcwd().replace('\\', '/') + '/' + data['output_dir']['path'].replace('\\', '/') + '/' + value.replace('\\', '/'))
+                if value:
+                    v = value.replace('\\', '/')
+                    paths.append(normpath(os.path.join(output_dir, v)))
             data[key] = paths
         # fix includes
         includes = []
         for key in data['include_paths']:
-            includes.append(getcwd().replace('\\', '/') + '/' + data['output_dir']['path'].replace('\\', '/') + '/' + key.replace('\\', '/'))
+            if key:
+                k = key.replace('\\', '/')
+                includes.append(normpath(os.path.join(output_dir, k)))
         data['include_paths'] = includes
-        data['linker_file'] = getcwd().replace('\\', '/') + '/' + data['output_dir']['path'].replace('\\', '/') + '/' + data['linker_file'].replace('\\', '/')
+
+        if 'linker_file' in data and data['linker_file']:
+            lf = data['linker_file'].replace('\\', '/')
+            data['linker_file'] = normpath(os.path.join(output_dir, lf))
+
         lib_paths = []
         for path in data['lib_paths']:
-            lib_paths.append(getcwd().replace('\\', '/') + '/' + data['output_dir']['path'].replace('\\', '/') + '/' + path.replace('\\', '/'))
+            if path:
+                p = path.replace('\\', '/')
+                lib_paths.append(paths.append(normpath(os.path.join(output_dir, p))))
         data['lib_paths'] = lib_paths
 
     def export_project(self):
@@ -95,56 +110,51 @@ class CMakeGccArm(Tool,Exporter):
     def get_generated_project_files(self):
         return {'path': self.workspace['path'], 'files': [self.workspace['files']['cmakelist']]}
 
-    def build_project(self):
+    def build_project(self, **kwargs):
         # cwd: relpath(join(project_path, ("gcc_arm" + project)))
         # > make all
         path = dirname(self.workspace['files']['cmakelist'])
-        logging.debug("Building GCC ARM project: %s" % path)
+        self.logging.debug("Building make project: %s" % path)
 
-        args = ['cmake', '.']
-        logging.debug(args)
+        build_path = join(path, "build")
+        if not exists(build_path):
+            os.mkdir(build_path)
+
+        args = ['cmake', "-S", path, "-B", build_path]
+        try:
+            ret_code = None
+            ret_code = subprocess.call(args)
+        except:
+            self.logging.error("Project: %s build error whilst calling cmake. Is it in your PATH?" % self.workspace['files']['cmakelist'])
+            return -1
+
+        args = ['make', "-C", build_path]
+        try:
+            args += ['-j', str(kwargs['jobs'])]
+        except KeyError:
+            pass
+        if 'verbose' in kwargs:
+            args += ["VERBOSE=%d" % (1 if kwargs['verbose'] else 0)]
+        args += ['all']
 
         try:
             ret_code = None
-            ret_code = subprocess.call(args, cwd=path)
+            ret_code = subprocess.call(args)
         except:
-            logging.error("Project: %s build error whilst calling cmake. Is it in your PATH?" % self.workspace['files']['cmakelist'])
+            self.logging.error("Project: %s build error whilst calling make. Is it in your PATH?" % self.workspace['files']['cmakelist'])
             return -1
         else:
             if ret_code != self.SUCCESSVALUE:
                 # Seems like something went wrong.
                 if ret_code < 3:
-                    logging.error("Project: make failed with the status: %s" %
-                                  (self.ERRORLEVEL[ret_code]))
+                    self.logging.error("Project: %s build failed with the status: %s" %
+                                  (self.ERRORLEVEL[ret_code], self.workspace['files']['cmakelist']))
                 else:
-                    logging.error("Project: make failed with unknown error. Returned: %s" %
-                                   (ret_code))
+                    self.logging.error("Project: %s build failed with unknown error. Returned: %s" %
+                                   (ret_code, self.workspace['files']['cmakelist']))
                 return -1
             else:
-
-                logging.info("CMake succeeded with the status: %s" %
-                             self.ERRORLEVEL[ret_code])
-
-                args = ['make', 'all']
-                logging.debug(args)
-
-                try:
-                    ret_code = None
-                    ret_code = subprocess.call(args, cwd=path)
-                except:
-                    logging.error("Project: build error whilst calling make. Is it in your PATH?")
-                    return -1
-                else:
-                    if ret_code != self.SUCCESSVALUE:
-                        # Seems like something went wrong.
-                        if ret_code < 3:
-                            logging.error("Project: make failed with the status: %s" %
-                                        (self.ERRORLEVEL[ret_code]))
-                        else:
-                            logging.error("Project:make failed with unknown error. Returned: %s" %
-                                        (ret_code))
-                        return -1
-                    else:
-                        logging.info("Build succeeded with the status: %s" %
-                                    self.ERRORLEVEL[ret_code])
-                        return 0
+                name = os.path.basename(self.workspace['path'])
+                self.logging.info("Built %s with the status: %s" %
+                             (name, self.ERRORLEVEL[ret_code]))
+                return 0

--- a/project_generator/tools/cmake.py
+++ b/project_generator/tools/cmake.py
@@ -13,13 +13,25 @@
 # limitations under the License.
 
 import copy
+import logging
+import subprocess
 from os import getcwd
+from os.path import dirname
 
 from .tool import Tool, Exporter
 from .gccarm import MakefileGccArm
 from ..util import SOURCE_KEYS
 
+logger = logging.getLogger('progen.tools.cmake_gcc_arm')
+
 class CMakeGccArm(Tool,Exporter):
+
+    SUCCESSVALUE = 0
+    ERRORLEVEL = {
+        0: 'no errors)',
+        1: 'targets not already up to date',
+        2: 'errors'
+    }
 
     generated_project = {
         'path': '',
@@ -82,3 +94,57 @@ class CMakeGccArm(Tool,Exporter):
 
     def get_generated_project_files(self):
         return {'path': self.workspace['path'], 'files': [self.workspace['files']['cmakelist']]}
+
+    def build_project(self):
+        # cwd: relpath(join(project_path, ("gcc_arm" + project)))
+        # > make all
+        path = dirname(self.workspace['files']['cmakelist'])
+        logging.debug("Building GCC ARM project: %s" % path)
+
+        args = ['cmake', '.']
+        logging.debug(args)
+
+        try:
+            ret_code = None
+            ret_code = subprocess.call(args, cwd=path)
+        except:
+            logging.error("Project: %s build error whilst calling cmake. Is it in your PATH?" % self.workspace['files']['cmakelist'])
+            return -1
+        else:
+            if ret_code != self.SUCCESSVALUE:
+                # Seems like something went wrong.
+                if ret_code < 3:
+                    logging.error("Project: make failed with the status: %s" %
+                                  (self.ERRORLEVEL[ret_code]))
+                else:
+                    logging.error("Project: make failed with unknown error. Returned: %s" %
+                                   (ret_code))
+                return -1
+            else:
+
+                logging.info("CMake succeeded with the status: %s" %
+                             self.ERRORLEVEL[ret_code])
+
+                args = ['make', 'all']
+                logging.debug(args)
+
+                try:
+                    ret_code = None
+                    ret_code = subprocess.call(args, cwd=path)
+                except:
+                    logging.error("Project: build error whilst calling make. Is it in your PATH?")
+                    return -1
+                else:
+                    if ret_code != self.SUCCESSVALUE:
+                        # Seems like something went wrong.
+                        if ret_code < 3:
+                            logging.error("Project: make failed with the status: %s" %
+                                        (self.ERRORLEVEL[ret_code]))
+                        else:
+                            logging.error("Project:make failed with unknown error. Returned: %s" %
+                                        (ret_code))
+                        return -1
+                    else:
+                        logging.info("Build succeeded with the status: %s" %
+                                    self.ERRORLEVEL[ret_code])
+                        return 0

--- a/project_generator/tools/cmake.py
+++ b/project_generator/tools/cmake.py
@@ -22,9 +22,9 @@ from .tool import Tool, Exporter
 from .gccarm import MakefileGccArm
 from ..util import SOURCE_KEYS
 
-logger = logging.getLogger('progen.tools.cmake_gcc_arm')
+logger = logging.getLogger('progen.tools.cmake')
 
-class CMakeGccArm(Tool,Exporter):
+class CMake(Tool,Exporter):
 
     ERRORLEVEL = {
         0: 'no errors',
@@ -46,16 +46,9 @@ class CMakeGccArm(Tool,Exporter):
         self.exporter = MakefileGccArm(workspace, env_settings)
         self.env_settings = env_settings
         self.logging = logging
-        self.workspace['preprocess_linker_file'] = True
 
-
-    @staticmethod
-    def get_toolnames():
-        return ['cmake_gcc_arm']
-
-    @staticmethod
-    def get_toolchain():
-        return 'gcc_arm'
+    def get_template(self):
+        raise NotImplementedError()
 
     def fix_paths_unix(self, data):
         # cmake seems to require unix paths
@@ -104,7 +97,7 @@ class CMakeGccArm(Tool,Exporter):
         self.fix_paths_unix(data_for_make)
 
         generated_projects['path'], generated_projects['files']['cmakelist'] = self.gen_file_jinja(
-            'cmakelistgccarm.tmpl', data_for_make, 'CMakeLists.txt', data_for_make['output_dir']['path'])
+            self.get_template(), data_for_make, 'CMakeLists.txt', data_for_make['output_dir']['path'])
         return generated_projects
 
     def get_generated_project_files(self):

--- a/project_generator/tools/cmake.py
+++ b/project_generator/tools/cmake.py
@@ -59,24 +59,22 @@ class CMake(Tool,Exporter):
             for value in data[key]:
                 # TODO: this needs to be fixed
                 if value:
-                    v = value.replace('\\', '/')
-                    paths.append(normpath(os.path.join(output_dir, v)))
+                    paths.append(normpath(os.path.join(output_dir, value)).replace('\\', '/'))
             data[key] = paths
 
         for k in ['include_paths', 'lib_paths']:
             paths = [path for path in data[k] if path]
-            paths = [normpath(os.path.join(output_dir, path.replace('\\', '/'))) for path in paths]
+            paths = [normpath(os.path.join(output_dir, path)).replace('\\', '/') for path in paths]
             data[k] = paths
 
         # Those paths are not fixed
         for k in ['pre_build_script', 'post_build_script']:
             paths = [path for path in data[k] if path]
-            paths = [normpath(os.path.join(os.getcwd(), path.replace('\\', '/'))) for path in paths]
+            paths = [normpath(os.path.join(os.getcwd(), path)).replace('\\', '/') for path in paths]
             data[k] = paths
 
         if 'linker_file' in data and data['linker_file']:
-            lf = data['linker_file'].replace('\\', '/')
-            data['linker_file'] = normpath(os.path.join(output_dir, lf))
+            data['linker_file'] = normpath(os.path.join(output_dir, data['linker_file'])).replace('\\', '/')
 
     def export_project(self):
         generated_projects = {}

--- a/project_generator/tools/cmake.py
+++ b/project_generator/tools/cmake.py
@@ -69,6 +69,8 @@ class CMake(Tool,Exporter):
 
         # Those paths are not fixed
         for k in ['pre_build_script', 'post_build_script']:
+            if k not in data:
+                continue
             paths = [path for path in data[k] if path]
             paths = [normpath(os.path.join(os.getcwd(), path)).replace('\\', '/') for path in paths]
             data[k] = paths

--- a/project_generator/tools/cmakearmcc.py
+++ b/project_generator/tools/cmakearmcc.py
@@ -1,0 +1,42 @@
+# Copyright 2015 0xc0170
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import copy
+import logging
+import subprocess
+
+from os.path import join, normpath, dirname, exists
+from .tool import Tool, Exporter
+from .cmake import CMake
+from .gccarm import MakefileGccArm
+from ..util import SOURCE_KEYS
+
+logger = logging.getLogger('progen.tools.cmake_armclang')
+
+class CMakeArmcc(CMake):
+    def __init__(self, workspace, env_settings):
+        super().__init__(workspace, env_settings)
+        self.logging = logging
+
+    @staticmethod
+    def get_toolnames():
+        return ['cmake_armcc']
+
+    @staticmethod
+    def get_toolchain():
+        return 'armcc'
+
+    def get_template(self):
+        return 'cmakelist_armcc.tmpl'

--- a/project_generator/tools/cmakearmcc.py
+++ b/project_generator/tools/cmakearmcc.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('progen.tools.cmake_armclang')
 
 class CMakeArmcc(CMake):
     def __init__(self, workspace, env_settings):
-        super().__init__(workspace, env_settings)
+        super(CMakeArmcc, self).__init__(workspace, env_settings)
         self.logging = logging
 
     @staticmethod

--- a/project_generator/tools/cmakearmclang.py
+++ b/project_generator/tools/cmakearmclang.py
@@ -37,7 +37,6 @@ class CMakeArmClang(CMake):
 
     @staticmethod
     def get_toolchain():
-        logger.info("HERE")
         return 'armclang'
 
     def get_template(self):

--- a/project_generator/tools/cmakearmclang.py
+++ b/project_generator/tools/cmakearmclang.py
@@ -1,0 +1,44 @@
+# Copyright 2015 0xc0170
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import copy
+import logging
+import subprocess
+
+from os.path import join, normpath, dirname, exists
+from .tool import Tool, Exporter
+from .cmake import CMake
+from .gccarm import MakefileGccArm
+from ..util import SOURCE_KEYS
+
+logger = logging.getLogger('progen.tools.cmake_armclang')
+
+class CMakeArmClang(CMake):
+    def __init__(self, workspace, env_settings):
+        super().__init__(workspace, env_settings)
+        self.logging = logging
+        self.workspace['preprocess_linker_file'] = True
+
+    @staticmethod
+    def get_toolnames():
+        return ['cmake_armclang']
+
+    @staticmethod
+    def get_toolchain():
+        logger.info("HERE")
+        return 'armclang'
+
+    def get_template(self):
+        return 'cmakelist_armclang.tmpl'

--- a/project_generator/tools/cmakearmclang.py
+++ b/project_generator/tools/cmakearmclang.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('progen.tools.cmake_armclang')
 
 class CMakeArmClang(CMake):
     def __init__(self, workspace, env_settings):
-        super().__init__(workspace, env_settings)
+        super(CMakeArmClang, self).__init__(workspace, env_settings)
         self.logging = logging
         self.workspace['preprocess_linker_file'] = True
 

--- a/project_generator/tools/cmakegccarm.py
+++ b/project_generator/tools/cmakegccarm.py
@@ -27,7 +27,7 @@ logger = logging.getLogger('progen.tools.cmake_gcc_arm')
 
 class CMakeGccArm(CMake):
     def __init__(self, workspace, env_settings):
-        super().__init__(workspace, env_settings)
+        super(CMakeGccArm, self).__init__(workspace, env_settings)
         self.logging = logging
         self.workspace['preprocess_linker_file'] = True
 

--- a/project_generator/tools/cmakegccarm.py
+++ b/project_generator/tools/cmakegccarm.py
@@ -1,0 +1,43 @@
+# Copyright 2015 0xc0170
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import copy
+import logging
+import subprocess
+
+from os.path import join, normpath, dirname, exists
+from .tool import Tool, Exporter
+from .cmake import CMake
+from .gccarm import MakefileGccArm
+from ..util import SOURCE_KEYS
+
+logger = logging.getLogger('progen.tools.cmake_gcc_arm')
+
+class CMakeGccArm(CMake):
+    def __init__(self, workspace, env_settings):
+        super().__init__(workspace, env_settings)
+        self.logging = logging
+        self.workspace['preprocess_linker_file'] = True
+
+    @staticmethod
+    def get_toolnames():
+        return ['cmake_gcc_arm']
+
+    @staticmethod
+    def get_toolchain():
+        return 'gcc_arm'
+
+    def get_template(self):
+        return 'cmakelist_gccarm.tmpl'

--- a/project_generator/tools_supported.py
+++ b/project_generator/tools_supported.py
@@ -23,6 +23,7 @@ from .tools.makearmclang import MakefileArmclang
 from .tools.sublimetext import SublimeTextMakeGccARM
 from .tools.gdb import GDB, ARMNoneEABIGDB, JLinkGDB
 from .tools.cmakegccarm import CMakeGccArm
+from .tools.cmakearmcc import CMakeArmcc
 from .tools.cmakearmclang import CMakeArmClang
 from .tools.visual_studio import VisualStudioMakeGCCARM, VisualStudioGDB
 
@@ -63,6 +64,7 @@ class ToolsSupported:
         'arm_none_eabi_gdb':    ARMNoneEABIGDB,
         'jlink_gdb':            JLinkGDB,
         'cmake_gcc_arm':        CMakeGccArm,
+        'cmake_armcc':          CMakeArmcc,
         'cmake_armclang':       CMakeArmClang,
         'visual_studio_gdb':    VisualStudioGDB,
         'visual_studio_make_gcc_arm': VisualStudioMakeGCCARM,

--- a/project_generator/tools_supported.py
+++ b/project_generator/tools_supported.py
@@ -22,7 +22,8 @@ from .tools.makearmcc import MakefileArmcc
 from .tools.makearmclang import MakefileArmclang
 from .tools.sublimetext import SublimeTextMakeGccARM
 from .tools.gdb import GDB, ARMNoneEABIGDB, JLinkGDB
-from .tools.cmake import CMakeGccArm
+from .tools.cmakegccarm import CMakeGccArm
+from .tools.cmakearmclang import CMakeArmClang
 from .tools.visual_studio import VisualStudioMakeGCCARM, VisualStudioGDB
 
 class ToolsSupported:
@@ -62,6 +63,7 @@ class ToolsSupported:
         'arm_none_eabi_gdb':    ARMNoneEABIGDB,
         'jlink_gdb':            JLinkGDB,
         'cmake_gcc_arm':        CMakeGccArm,
+        'cmake_armclang':       CMakeArmClang,
         'visual_studio_gdb':    VisualStudioGDB,
         'visual_studio_make_gcc_arm': VisualStudioMakeGCCARM,
     }

--- a/project_generator/tools_supported.py
+++ b/project_generator/tools_supported.py
@@ -96,5 +96,4 @@ class ToolsSupported:
             return None
 
     def get_supported(self):
-        return list(self.TOOLS_DICT.keys()) + list(self.TOOLS_ALIAS.keys())
-
+        return list(self.TOOLS_DICT.keys()) + list(self.TOOLS_ALIAS.keys()) + self.TOOLCHAINS

--- a/tests/test_commands/test_build.py
+++ b/tests/test_commands/test_build.py
@@ -98,6 +98,13 @@ class TestBuildCommand(TestCase):
 
         assert result == -1
 
+    def test_build_project_cmake_gcc_arm_tool(self):
+        args = self.parser.parse_args(['build','-f','test_workspace/projects.yaml','-p',
+            'project_2', '-t', 'cmake_gcc_arm'])
+        result = build.run(args)
+
+        assert result == -1
+
     def test_build_project_make_armcc_tool(self):
         args = self.parser.parse_args(['build','-f','test_workspace/projects.yaml','-p',
             'project_2', '-t', 'make_armcc'])

--- a/tests/test_commands/test_build.py
+++ b/tests/test_commands/test_build.py
@@ -96,14 +96,10 @@ class TestBuildCommand(TestCase):
             'project_2', '-t', 'make_gcc_arm'])
         result = build.run(args)
 
-        assert result == -1
-
     def test_build_project_cmake_gcc_arm_tool(self):
         args = self.parser.parse_args(['build','-f','test_workspace/projects.yaml','-p',
             'project_2', '-t', 'cmake_gcc_arm'])
         result = build.run(args)
-
-        assert result == -1
 
     def test_build_project_make_armcc_tool(self):
         args = self.parser.parse_args(['build','-f','test_workspace/projects.yaml','-p',
@@ -141,5 +137,3 @@ class TestBuildCommand(TestCase):
         args = self.parser.parse_args(['build','-f','test_workspace/projects.yaml','-p',
             'project_2', '-t', 'sublime_make_gcc_arm'])
         result = build.run(args)
-
-        assert result == -1

--- a/tests/test_tools/test_cmake.py
+++ b/tests/test_tools/test_cmake.py
@@ -20,7 +20,7 @@ from unittest import TestCase
 from project_generator.generate import Generator
 from project_generator.project import Project
 from project_generator.settings import ProjectSettings
-from project_generator.tools.cmake import CMakeGccArm
+from project_generator.tools.cmakegccarm import CMakeGccArm
 
 from .simple_project import project_1_yaml, projects_1_yaml
 

--- a/tests/test_tools_supported.py
+++ b/tests/test_tools_supported.py
@@ -22,7 +22,7 @@ from project_generator.tools.gccarm import MakefileGccArm
 from project_generator.tools.makearmcc import MakefileArmcc
 from project_generator.tools.eclipse import EclipseGnuARM
 from project_generator.tools.sublimetext import SublimeTextMakeGccARM
-from project_generator.tools.cmake import CMakeGccArm
+from project_generator.tools.cmakegccarm import CMakeGccArm
 from project_generator.tools.visual_studio import VisualStudioMakeGCCARM, VisualStudioGDB
 
 


### PR DESCRIPTION
This build on #474 (so not that many commits)

I completely rewrote using `target_*` commands rather than appending variables, this means CMake is much more helpful with escaping flags, and opens the way to a workspace-wide CMake. Armclang support was a little more tedious because it feel like I have to fight against the support in CMake.
Using the `-o` option in `build` and `generate` commands allows to pass options to the toolchain `build()` function, e.g. `-o generator=<g>` selects the CMake generator, the options for `<g>` are `make` (default), `ninja`, `mingw-make`, `nmake`.

Using CMake can be faster with the `make` back-end than progen's make tool option with workspace (see #480)