### PR TITLE
Remove broken include files from Eclipse project template

### DIFF
--- a/project_generator/templates/eclipse.project.tmpl
+++ b/project_generator/templates/eclipse.project.tmpl
@@ -38,11 +38,5 @@
 			<type>1</type>
 			<locationURI>{{file.path}}</locationURI>
 		</link> {% endfor %}{% endfor %}
-		{% for group_name,files in include_files.items() %} {% for file in files %}
-		<link>
-			<name>{{group_name}}/{{file.name}}</name>
-			<type>1</type>
-			<locationURI>{{file.path}}</locationURI>
-		</link> {% endfor %}{% endfor %}
 	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
This fixes Eclipse project generation. There may be a more complete fix that restores the include files, but this worked for me to at least be able to open the project in Eclipse and use for debugging.