### PR TITLE
Fix the compatibility of armcc with static libraries

### DIFF
--- a/project_generator/templates/makefile.tmpl
+++ b/project_generator/templates/makefile.tmpl
@@ -59,13 +59,16 @@ LD_SCRIPT = {{linker_file}}
 CC_SYMBOLS = {% for symbol in macros %} -D{{symbol}} {% endfor %}
 ASM_SYMBOLS = {% block ASM_SYMBOLS %}{% endblock %}
 
+{% block LIBS %}
 LIBS = {% for library in libraries %} -l{{library}} {% endfor %}
 {% if standard_libraries %}
 LIBS += -Wl,--start-group  {% for library in standard_libraries %} -l{{library}} {% endfor %} -Wl,--end-group
 {% endif %}
+{% endblock %}
 
+{% block LIB_PATHS %}
 LIB_PATHS = {% for path in lib_paths %} -L{{path}} {% endfor %}
-
+{% endblock %}
 
 # directories
 INC_DIRS = {% for path in include_paths %} {{path}} {% endfor %}
@@ -113,7 +116,7 @@ LD_CPP_FLAGS = {% block LD_CPP_FLAGS %}{% endblock %}
 ARFLAGS = cr
 
 ifeq ($(OS),Windows_NT)
-	RM = rmdir /s /q
+	RM = cmd /c rd /s /q
 else
 	RM = rm -rf
 endif
@@ -307,7 +310,11 @@ $(TARGET_OUT): $(C_OBJS) $(CPP_OBJS) $(S_OBJS)
 # Other Targets
 clean:
 	@echo 'Removing entire out directory'
+ifeq ($(OS),Windows_NT)
+	$(at)-$(RM) $(subst /,\\,$(OBJ_FOLDER))
+else
 	$(at)$(RM) $(OBJ_FOLDER)* $(OBJ_FOLDER)
+endif
 	@echo ' '
 
 help:

--- a/project_generator/templates/makefile_armcc.tmpl
+++ b/project_generator/templates/makefile_armcc.tmpl
@@ -27,6 +27,9 @@
 {% block CFLAGS %}$(COMMON_FLAGS) $(C_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c{% endblock %}
 {% block CXXFLAGS %}$(COMMON_FLAGS) $(CXX_FLAGS) $(INC_DIRS_F) $(CC_SYMBOLS) -c{% endblock %}
 {% block ASFLAGS %}$(COMMON_FLAGS) $(ASM_FLAGS) $(INC_DIRS_F) $(ASM_SYMBOLS){% endblock %}
-{% block LD_OPTIONS %}--strict --scatter $(LD_SCRIPT) --map --list $(OBJ_FOLDER)$(TARGET).map --predefine -D'{{macros|join("' --predefine -D'")}}' $(patsubst %,--predefine "%",$(INC_DIRS_F)){% endblock %}
+{% block LD_OPTIONS %}--strict --scatter "$(LD_SCRIPT)" --map --list $(OBJ_FOLDER)$(TARGET).map --predefine -D'{{macros|join("' --predefine -D'")}}' $(patsubst %,--predefine "%",$(INC_DIRS_F)){% endblock %}
 {% block CPP_FLAGS %}-E{% endblock %}
 {% block ASM_SYMBOLS %}--cpreproc --cpreproc_opts=-D'{{macros|join("',-D'")}}'{% endblock %}
+
+{% block LIBS %}LIBS = {% for library in libraries %} {{library}}{% endfor %}{% endblock %}
+{% block LIB_PATHS %}LIB_PATHS = {% for path in lib_paths %} --userlibpath "{{path}}" {% endfor %}{% endblock %}

--- a/project_generator/tools/makearmcc.py
+++ b/project_generator/tools/makearmcc.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import ntpath
+
 from copy import deepcopy
 import logging
 
@@ -31,6 +34,21 @@ class MakefileArmcc(MakefileTool):
     @staticmethod
     def get_toolchain():
         return 'armcc'
+
+    def _get_libs(self, project_data):
+        project_data['lib_paths'] =[]
+        project_data['libraries'] =[]
+        for lib in project_data['source_files_lib']:
+            head, tail = ntpath.split(lib)
+            file = tail
+            if (os.path.splitext(file)[1] != ".lib"):
+                self.logging.debug("Found %s lib with non-valid extension (!=.lib)" % file)
+                continue
+            else:
+                lib_path = ntpath.join(self.workspace['output_dir']['path'], head)
+                lib_path = ntpath.abspath(lib_path)
+                project_data['lib_paths'].append(lib_path)
+                project_data['libraries'].append(file)
 
     def export_project(self):
         """ Processes misc options specific for ARMCC, and run generator """


### PR DESCRIPTION
1. armcc uses --userlibpath to specify the library path;
2. after armasm uses the --pd "__MICROLIB SETA 1" parameter, a build error occurs when using the windows path (..\..\cmsis\Device\ST\STM32F4xx\Source\Templates\gcc_ride7/startup_stm32f40_41xxx.s), so change the files to a Unix-like path.