### PR TITLE
Use setuptools_scm to get package version from git tags

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+*.bat       text eol=crlf
+*.ewd       text eol=crlf
+*.ewp       text eol=crlf
+*.eww       text eol=crlf
+*.in        text
+*.ini       text
+*.json      text
+*.md        text
+*.py        text
+*.rst       text
+*.tmpl      text
+*.txt       text
+*.uvmpw     text eol=crlf
+*.uvoptx    text eol=crlf
+*.uvproj    text
+*.xml       text
+*.yaml      text
+*.yml       text
+.git_archival.txt   export-subst

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs
+project_generator/_version.py
 
 # Installer logs
 pip-log.txt

--- a/project_generator/__init__.py
+++ b/project_generator/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from ._version import version as __version__

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ def read(fname):
 
 setup(
     name='project_generator',
-    version='0.11.1',
     description='Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!',
     author='Martin Kojtal',
     author_email='c0170@rocketmail.com',
@@ -35,10 +34,21 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: C",
+        "Programming Language :: C++",
         "Topic :: Software Development"
+        "Topic :: Software Development :: Embedded Systems",
     ],
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
+    use_scm_version={
+        'local_scheme': 'dirty-tag',
+        'write_to': 'project_generator/_version.py'
+    },
+    setup_requires=[
+        'setuptools>=40.0',
+        'setuptools_scm!=1.5.3,!=1.5.4',
+        'setuptools_scm_git_archive',
+        ],
     install_requires=[
         'pyyaml>=5.1,<6.0',
         'Jinja2>2.0<3.0',


### PR DESCRIPTION
This changes makes it so you no longer have to update the version in `setup.py`. The version will be automatically picked up from the latest git tag.