### PR TITLE
List subcommand: default arguments work, added --all.

### DIFF
--- a/project_generator/commands/build.py
+++ b/project_generator/commands/build.py
@@ -1,4 +1,5 @@
 # Copyright 2015 0xc0170
+# Copyright (c) 2021 Chris Reed
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +31,7 @@ def run(args):
     any_export_failed = False
     for project_name in combined_projects:
         for project in generator.generate(project_name):
+            project.debug_dump = args.dump_debug_yaml
             clean_failed = False
             if args.clean and project.clean(args.tool) == -1:
                 clean_failed = True # So we don't attempt to generate or build this project.
@@ -52,6 +54,9 @@ def setup(subparser):
                         help='Increase the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument('-q', dest='quietness', action='count', default=0,
                         help='Decrease the verbosity of the output (repeat for less verbose output)')
+    subparser.add_argument(
+        "--dump-debug-yaml", action="store_true",
+                        help="Write processed yaml to a <project>-dump.yaml file for debugging.")
     subparser.add_argument(
         "-f", "--file", help="YAML projects file", default='projects.yaml',
         type=argparse_filestring_type)

--- a/project_generator/commands/generate.py
+++ b/project_generator/commands/generate.py
@@ -1,4 +1,5 @@
 # Copyright 2014-2015 0xc0170
+# Copyright (c) 2021 Chris Reed
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +40,7 @@ def _generate_project(project, args):
         logger.info("Generating %s for %s in workspace %s", args.tool, project.name, project.workspace_name)
     else:
         logger.info("Generating %s for %s", args.tool, project.name)
+    project.debug_dump = args.dump_debug_yaml
     if project.generate(args.tool, copied=args.copy, copy=args.copy) == -1:
         export_failed = True
     if args.build:
@@ -94,6 +96,9 @@ def setup(subparser):
                         help='Increase the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument('-q', dest='quietness', action='count', default=0,
                         help='Decrease the verbosity of the output (repeat for more verbose output)')
+    subparser.add_argument(
+        "--dump-debug-yaml", action="store_true",
+                        help="Write processed yaml to a <project>-dump.yaml file for debugging.")
     subparser.add_argument(
         "-f", "--file", help="YAML projects file", default='projects.yaml', type=argparse_filestring_type)
     subparser.add_argument(

--- a/project_generator/commands/list_projects.py
+++ b/project_generator/commands/list_projects.py
@@ -24,11 +24,14 @@ help = 'List general progen data as projects, tools or targets'
 
 
 def run(args):
-    if args.file and os.path.exists(args.file):
+    if not args.all:
         generator = Generator(args.file)
         for project in generator.generate():
             if args.section == 'targets':
-                print("%s supports: %s" % (project.name, project.project['target']))
+                try:
+                    print("%s supports: %s" % (project.name, project.project['target']))
+                except KeyError:
+                    print("%s supports: (no targets specified)" % project.name)
             elif args.section == 'projects':
                 print (project.name)
             elif args.section == 'tools':
@@ -36,13 +39,13 @@ def run(args):
                 print("%s supports: %s" % (project.name, ", ".join(tools)))
     else:
         if args.section == 'targets':
-            print("\nProgen supports the following targets:\n")
-            print("\n".join(ProGenTargets().get_targets()))
+            print("Progen supports the following targets:\n")
+            print("\n".join(sorted(ProGenTargets().get_targets())))
         elif args.section == 'tools':
-            print("\nProgen supports the following tools:\n")
-            print("\n".join(ToolsSupported().get_supported()))
+            print("Progen supports the following tools:\n")
+            print("\n".join(sorted(ToolsSupported().get_supported())))
         elif args.section == 'projects':
-            print("\nFile needs to be defined for projects.")
+            print("--all does not apply to projects.")
     return 0
 
 
@@ -51,6 +54,7 @@ def setup(subparser):
                         help='Increase the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument('-q', dest='quietness', action='count', default=0,
                         help='Decrease the verbosity of the output (repeat for more verbose output)')
-    subparser.add_argument("section", choices = ['targets','tools','projects'],
+    subparser.add_argument("section", choices = ['targets','tools','projects'], nargs="?",
                            help="What section you would like listed", default='projects')
-    subparser.add_argument("-f", "--file", help="YAML projects file", type=argparse_filestring_type)
+    subparser.add_argument("-f", "--file", help="YAML projects file", default='projects.yaml', type=argparse_filestring_type)
+    subparser.add_argument("-a", "--all", help="List all available options.", action="store_true")

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -182,6 +182,7 @@ class Project:
         self.settings = settings
         self.name = name
         self.workspace_name = workspace_name
+        self.debug_dump = False
         self.project = {}
         self.project['common'] = {}
         self.project['export'] = {} # merged common and tool
@@ -539,14 +540,10 @@ class Project:
                 logger.debug("Copying sources to the output directory")
                 self._copy_sources_to_generated_destination()
             # dump a log file if debug is enabled
-            if logger.isEnabledFor(logging.DEBUG):
-                dump_data = {}
-                dump_data['common'] = self.project['common']
-                dump_data['tool_specific'] = self.project['tool_specific']
-                dump_data['merged'] = self.project['export']
+            if self.debug_dump:
                 log_path = os.path.join(os.getcwd(), "%s-dump.yaml" % self.name)
                 with open(log_path, 'w') as f:
-                    f.write(yaml.dump(dump_data))
+                    f.write(yaml.dump(self.project))
             files = exporter(self.project['export'], self.settings).export_project()
             generated_files[export_tool] = files
         self.generated_files = generated_files


### PR DESCRIPTION
- The section argument correctly defaults to 'projects'.
- Defaults to `projects.yaml` file.
- Added `--all` argument to show all supported possibilities, instead of relying on not having a default project file.
- Handle projects with no defined targets.

Also includes a change to separate debug logging from writing of the `project-dump.yaml`. Now the dump file is controlled directly with `--dump-debug-yaml`.