### PR TITLE
Convert to PEP517; bump dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ test_projects
 
 # Mac files
 .DS_Store
+
+# virtualenvs
+/venv*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+# These are the assumed default build requirements from pip:
+# https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
+requires = [
+    "setuptools>=51",
+    "wheel",
+    "setuptools_scm[toml]>=6.0",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "project_generator/_version.py"
+local_scheme = "dirty-tag"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,46 @@
+[metadata]
+name = project_generator
+description = Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!
+long_description = file: README.md
+long_description_content_type = text/markdown
+maintainer = Martin Kojtal
+maintainer_email = c0170@rocketmail.com
+url = https://github.com/project-generator/project_generator
+keywords = c cpp project generator embedded
+license = Apache 2.0
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Environment :: Console
+    License :: OSI Approved :: Apache Software License
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Operating System :: Unix
+    Programming Language :: Python
+    Programming Language :: C
+    Programming Language :: C++
+    Topic :: Software Development
+    Topic :: Software Development :: Embedded Systems
+project_urls =
+    Home = https://github.com/project-generator/project_generator
+    Issues = https://github.com/project-generator/project_generator/issues
+    Documentation = https://github.com/project-generator/project_generator/wiki
+
+[options]
+zip_safe = True
+include_package_data = True
+packages = find:
+install_requires =
+    pyyaml>=6.0,<7.0
+    Jinja2>=3.0,<4.0
+    xmltodict
+    project_generator_definitions>=0.2.2,<0.3.0
+
+[options.entry_points]
+console_scripts =
+    project_generator = project_generator.__main__:main
+    progen = project_generator.__main__:main
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # Copyright 2014-2015 0xc0170
+# Copyright (c) 2021 Chris Reed
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,61 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
-def read(fname):
-    with open(os.path.join(os.path.dirname(__file__), fname), 'r') as f:
-        return f.read()
-
-setup(
-    name='project_generator',
-    description='Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!',
-    author='Martin Kojtal',
-    author_email='c0170@rocketmail.com',
-    keywords="c cpp project generator embedded",
-    url="https://github.com/project-generator/project_generator",
-    license="Apache 2.0",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Environment :: Console",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: C",
-        "Programming Language :: C++",
-        "Topic :: Software Development"
-        "Topic :: Software Development :: Embedded Systems",
-    ],
-    long_description=read('README.md'),
-    long_description_content_type='text/markdown',
-    use_scm_version={
-        'local_scheme': 'dirty-tag',
-        'write_to': 'project_generator/_version.py'
-    },
-    setup_requires=[
-        'setuptools>=40.0',
-        'setuptools_scm!=1.5.3,!=1.5.4',
-        'setuptools_scm_git_archive',
-        ],
-    install_requires=[
-        'pyyaml>=5.1,<6.0',
-        'Jinja2>2.0<3.0',
-        'xmltodict',
-        'project_generator_definitions>=0.2.2,<0.3.0',
-        ],
-    packages=find_packages(),
-    entry_points={
-        'console_scripts': [
-            "project_generator=project_generator.__main__:main",
-            "progen=project_generator.__main__:main",
-        ]
-    },
-    include_package_data=True,
-    zip_safe=True,
-    options={
-        'bdist_wheel': {
-            'universal': True,
-        },
-    },
-)
+setup()


### PR DESCRIPTION
This PR switches over to the standard PEP517 package build system. All metadata was transferred as-is to `setup.cfg`.

It also updates pyyaml to >=6.0,<7.0 and Jinja2 to >=3.0,4.0.

Note that when building for release, you now need to use the `build` package. Just install via pip, then run as `python -mbuild`. By default it will build both an sdist and wheel.