### PR TITLE
Add ARMC6 support for uvision/uvision5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.6
         - 3.7
         - 3.8
         - 3.9
         - "3.10"
+        - "3.11"
 
     steps:
     - uses: actions/checkout@v2

--- a/project_generator/templates/uvision.uvproj
+++ b/project_generator/templates/uvision.uvproj
@@ -7,6 +7,7 @@
 			<TargetName></TargetName>
 			<ToolsetNumber>0x4</ToolsetNumber>
 			<ToolsetName>ARM-ADS</ToolsetName>
+			<uAC6>1</uAC6>
 			<TargetOption>
 				<TargetCommonOption>
 					<Device>LPC1768</Device>
@@ -356,6 +357,8 @@
 						<uSurpInc>0</uSurpInc>
 						<uC99>1</uC99>
 						<useXO>0</useXO>
+						<v6Lang>6</v6Lang>
+						<v6LangP>3</v6LangP>
 						<VariousControls>
 							<MiscControls></MiscControls>
 							<Define></Define>

--- a/project_generator/tools_supported.py
+++ b/project_generator/tools_supported.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from .tools.iar import IAREmbeddedWorkbench
-from .tools.uvision import Uvision, Uvision5
+from .tools.uvision import Uvision, Uvision5, UvisionArmC6, Uvision5ArmC6
 from .tools.coide import Coide
 from .tools.eclipse import EclipseGnuARM
 from .tools.gccarm import MakefileGccArm
@@ -33,6 +33,7 @@ class ToolsSupported:
     # Default tools - aliases
     TOOLS_ALIAS = {
         'uvision':       'uvision4',
+        'uvision_armc6': 'uvision4_armc6',
         'iar':           'iar_arm',
         'make_gcc':      'make_gcc_arm',
         'gcc_arm':       'make_gcc_arm',
@@ -53,10 +54,12 @@ class ToolsSupported:
     TOOLS_DICT = {
         'iar_arm':              IAREmbeddedWorkbench,
         'uvision4':             Uvision,
+        'uvision4_armc6':       UvisionArmC6,
         'uvision5':             Uvision5,
+        'uvision5_armc6':       Uvision5ArmC6,
         'coide':                Coide,
         'make_gcc_arm':         MakefileGccArm,
-        'make_armcc':           MakefileArmcc, 
+        'make_armcc':           MakefileArmcc,
         'make_armclang':        MakefileArmclang,
         'eclipse_make_gcc_arm': EclipseGnuARM,
         'sublime_make_gcc_arm': SublimeTextMakeGccARM,


### PR DESCRIPTION
Fixes #447 

The handling of scatter files is still complicated because you need to replace
```
#! armcc -E
```
by something like:
```
#! armclang --target=arm-arm-none-eabi -march=armv7-m -E -x c
```

Meaning you need two otherwise identical scatter files to support `uvision` with ARMC5 and ARMC6 (and a third one if you want to support `make_armclang`).