### PR TITLE
Use comment blocks when appropriate

### DIFF
--- a/project_generator/init_yaml.py
+++ b/project_generator/init_yaml.py
@@ -54,11 +54,9 @@ def _scan(section, directory, extensions):
                     #get all the folders along the path
                     dirs = relpath.split(os.path.sep)
                     for i in range(1, len(dirs)+1):
-                        """ add all combinations of them, because we don't know how they will be referenced in program files
-                            Example - there is a .h file in the path Here\is\include\include.h
-                            We want to catch any possible combo, so add Here, Here\is, and Here\is\include
-
-                        """
+                        # add all combinations of them, because we don't know how they will be referenced in program files
+                        # Example - there is a .h file in the path Here\is\include\include.h
+                        # We want to catch any possible combo, so add Here, Here\is, and Here\is\include
                         data_dict.append(os.path.normpath(os.path.sep.join(dirs[:i])))
                 else:
                     data_dict.append(os.path.normpath(os.path.join(relpath, filename)))


### PR DESCRIPTION
The docstring here triggers a Syntax Warning on Python 3.12, which in time will be raised to a SyntaxError, due to an invalid escape character.

When explaining the intricacies of code for developers, use comments.